### PR TITLE
markdown.css improvements

### DIFF
--- a/Resources/markdown.css
+++ b/Resources/markdown.css
@@ -2,6 +2,7 @@
   /* Base Light */
   --textPrimary: #24292E;
   --background: #ffffff;
+  --body-border-color: #dfdfdf;
   --link: #0366d6;
   --link-highlight: rgba(3, 102, 214, 0.08);
   --code-background: #f7f7f9;
@@ -52,6 +53,7 @@
     /* Base Dark */
   --textPrimary: #c9d1d9;
   --background: #0d1117;
+  --body-border-color: #31363C;
   --link: #58a6ff;
   --link-highlight: rgba(3, 102, 214, 0.08);
   --code-background: #2f3438;
@@ -99,8 +101,9 @@
 }
 
 /*Syntax Highlight*/
-pre.hl	{ background-color: var(--hl_Background); }
-.hl.num { color: var(--hl_Number); font-weight: normal;}
+pre.hl	{ background-color: var(--hl_Background);
+}
+.hl.num { color: var(--hl_Number); }
 .hl.esc { color: var(--hl_Escape); font-weight: normal;}
 .hl.str { color: var(--hl_String); font-weight: normal;}
 .hl.pps { color: var(--hl_String_Pre_Processor); font-weight: normal;}
@@ -117,6 +120,10 @@ pre.hl	{ background-color: var(--hl_Background); }
 .hl.kwe { color: var(--hl_Keyword-5); font-weight: normal;}
 .hl.kwf { color: var(--hl_Keyword-6); font-weight: normal;}
 
+
+pre {
+  max-width: 902px;;
+}
 * {
   box-sizing: border-box;
 }
@@ -130,7 +137,7 @@ html {
   margin: 0;
   -webkit-text-size-adjust: none;
   text-size-adjust: none;
-  font-family: -apple-system;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji, Segoe UI Emoji;
 }
 
 body {
@@ -196,12 +203,15 @@ input[type="checkbox"] {
   transform: translate(0px);
 }
 
-/* --- */
-
 .markdown-body {
+  border: solid var(--body-border-color);
+  border-width: thin;
+  margin: auto;
+  max-width: 902px;
   font-size: inherit;
   line-height: 1.5;
   word-wrap: break-word;
+  padding: 32px;
 }
 
 .markdown-body kbd {


### PR DESCRIPTION
* better margins ( close to original )
* the page body is center-aligned and the border has been added. To see the difference, you have to make the quicklook window full screen. or increase the width.
* maximum page and pre width is 902px;

note: If the viewport is less than 902 pixels, I want the border to disappear. but I had a problem. I'll post a separate message on the Discussions page for this.