### PR TITLE
checkbox dark style and size fix

### DIFF
--- a/Resources/markdown.css
+++ b/Resources/markdown.css
@@ -217,9 +217,15 @@ pre, code, kbd {
   display: none;
 }
 
+@media (prefers-color-scheme: dark) {
+  input[type="checkbox"] {
+    filter: invert(85%) brightness(1.5);
+  }
+}
 /* Fix checkboxes looking cut off when they render larger than the default size */
 input[type="checkbox"] {
   transform: translate(0px);
+  width: 14px; height: 14px;
 }
 
 


### PR DESCRIPTION
- New  checkbox size is 14px (original github size)
- Dark style checkbox fix ( filter: invert(85%) brightness(1.5); )

before - after

![a](https://user-images.githubusercontent.com/36481442/103425937-ddb27500-4bc6-11eb-8afd-2248e1fc1ecc.gif)
