### PR TITLE
Fix Cmd+C copy in Quick Look preview

### DIFF
--- a/QLExtension/Info.plist
+++ b/QLExtension/Info.plist
@@ -27,7 +27,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>QLIsDataBasedPreview</key>
-			<true/>
+			<false/>
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>com.unknown.md</string>

--- a/QLExtension/PreviewViewController.swift
+++ b/QLExtension/PreviewViewController.swift
@@ -13,12 +13,11 @@ import external_launcher
 
 class MyWKWebView: WKWebView {
     override var canBecomeKeyView: Bool {
-        return false
+        return true
     }
 
     override func becomeFirstResponder() -> Bool {
-        // Quick Look window do not allow first responder child.
-        return false
+        return true
     }
 }
 


### PR DESCRIPTION
Fixes #177

### Problem

Cmd+C doesn't work in Quick Look preview on macOS Tahoe 26.2+, while right-click copy works fine.

### Root Cause

Two issues combined to prevent keyboard input:

1. `MyWKWebView` explicitly blocked keyboard focus by returning `false` for `canBecomeKeyView` and `becomeFirstResponder`
2. With `QLIsDataBasedPreview=true`, macOS 12+ uses the `providePreview` method which bypasses our WKWebView entirely, giving us no control over keyboard handling

### Fix

1. Allow `MyWKWebView` to become first responder
2. Set `QLIsDataBasedPreview=false` to use the `preparePreviewOfFile` code path where our WKWebView handles the preview

### Testing

- [x] Select text and press Cmd+C — text is copied to clipboard
- [x] Right-click copy still works
- [x] Preview rendering unchanged

### Changes

- `QLExtension/PreviewViewController.swift`: `MyWKWebView` now returns `true` for `canBecomeKeyView` and `becomeFirstResponder`
- `QLExtension/Info.plist`: `QLIsDataBasedPreview` set to `false`