### PR TITLE
Enable YAML header rendering for all .md files by default

### DIFF
--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -126,7 +126,7 @@ class Settings: Codable {
     @objc var tagFilterExtension: Bool = true
     @objc var taskListExtension: Bool = true
     @objc var yamlExtension: Bool = true
-    @objc var yamlExtensionAll: Bool = false
+    @objc var yamlExtensionAll: Bool = true
     
     @objc var footnotesOption: Bool = true
     @objc var hardBreakOption: Bool = false


### PR DESCRIPTION
## Summary

Flip the factory default of `yamlExtensionAll` from `false` to `true`, so plain `.md` files get the same structured frontmatter rendering that `.rmd` / `.qmd` already get.

## Motivation

With the current default, a typical Jekyll / Hugo / Zola / Obsidian file like:

```markdown
---
title: My post
date: 2025-01-01
tags: [foo, bar]
---

Body...
```

…is fed to CommonMark as-is. The opening `---` gets interpreted as a **setext H2 underline**, so `title: My post` becomes a heading, and the remaining keys collapse into a single paragraph. The result looks broken even though the YAML rendering code already exists and works — it's just gated to `.rmd` / `.qmd`.

Markdown frontmatter is now the dominant pattern across static-site generators and note-taking apps, so enabling it by default better matches user expectations.

## Change

Single line in `QLMarkdown/Settings.swift`:

```diff
-    @objc var yamlExtensionAll: Bool = false
+    @objc var yamlExtensionAll: Bool = true
```

No logic changes — the existing `renderYamlHeader` path at `Settings+render.swift:105` already handles this cleanly when the flag is on.

## Behavior

- **New installs**: `.md` frontmatter renders as the existing table layout.
- **Existing users**: unaffected — their preference is already persisted in `UserDefaults`.
- **Opt-out**: Preferences → *YAML header* popup → *".rmd, .qmd files"* restores the old scope. Or switch it off entirely.

## Test plan

- [x] Build & install locally, Quick Look a `.md` file with YAML frontmatter → renders as a table
- [x] Confirm the same file with the preference switched back to *".rmd, .qmd files"* renders as before (falls through to CommonMark)
- [x] `.rmd` / `.qmd` files unchanged