### PR TITLE
Follow relative .md links in the preview window

### DIFF
--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -1562,6 +1562,11 @@ extension ViewController: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url, url.isFileURL, url.pathExtension.lowercased() == "md", FileManager.default.fileExists(atPath: url.path) {
+            openMarkdown(file: url)
+            decisionHandler(.cancel)
+            return
+        }
         if !Settings.shared.openInlineLink, navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url, url.scheme != "file" {
             let r = NSWorkspace.shared.open(url)
             // print(r, url.absoluteString)


### PR DESCRIPTION
## Summary

When a Markdown document rendered in the QLMarkdown app contains a relative link to another `.md` file (e.g. a `README.md` linking to `active-listings.md`), clicking the link currently causes the web view to navigate to the raw markdown source as plain text. This PR makes such links open the target document in QLMarkdown instead, using the existing `openMarkdown(file:)` path (the same route used when opening a file from Finder or via `openDocument:`).

## Change

`ViewController.decidePolicyFor` now checks, before the existing `openInlineLink` branch, whether the activated link is a `file://` URL with a `.md` extension pointing at an existing file. If so, it calls `openMarkdown(file:)` and cancels the web view navigation.

Scope is intentionally narrow:
- Only `.linkActivated` navigations (not redirects or programmatic loads).
- Only `file://` URLs with a `.md` extension (consistent with the check already used in `AppDelegate.application(_:openFile:)`).
- Only when the target exists on disk.

## Not included

- The Quick Look extension (`QLExtension/PreviewViewController.swift`) has the same limitation but is sandboxed and has separate design questions (in-place re-render vs. handoff to the main app). Happy to follow up in a separate PR if this direction is welcome.
- Fragment links (`other.md#section`) open the target file but do not scroll to the anchor — `openMarkdown(file:)` does not currently accept a fragment.

## Test plan

- [ ] Preview a `README.md` containing `[foo](other.md)` where `other.md` is a sibling file; click the link → `other.md` renders in the current window.
- [ ] External `http(s)` links still respect the `openInlineLink` setting.
- [ ] In-page anchor links (`#section`) still navigate within the current document.
- [ ] Clicking a link to a non-existent `.md` falls through to the default behavior (no silent swallow).