### PR TITLE
Fix inline math extension false positive on currency $ signs

### DIFF
--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -803,14 +803,15 @@ table.debug td {
         // Gate MathJax injection strictly on whether cmark's math extension actually rendered
         // a math node. The legacy `|| body.contains("$")` fallback was removed: with the
         // pandoc-rules fix in cmark-extra/math_ext.c, `rendered_count` is now reliable for
-        // currency-only files. Re-adding the fallback re-introduces the currency-mangling bug
-        // (MathJax v3's `inlineMath: [['$', '$']]` matches `$1.50` pairs client-side regardless
-        // of what cmark did).
-        // KNOWN LIMITATION: mixed files containing BOTH real math (`$x=1$`) and currency (`$100`)
-        // still mangle the currency — MathJax loads for the real math and then re-matches every
-        // `$...$` pair on the page. Fixing that requires either a body post-process to escape
-        // non-math `$` to `\$` (relying on `processEscapes: true` below), or switching cmark-extra
-        // + MathJax to `\(...\)` inline delimiters. Out of scope here.
+        // currency-only files. Re-adding the fallback re-introduces the currency-mangling bug.
+        //
+        // Mixed files (real math AND currency in the same document) are handled by configuring
+        // MathJax to use `\(...\)` / `\[...\]` as the only delimiters, and post-processing the
+        // rendered body so the inside of each `<span class='hl math'>` / `<div class='hl math'>`
+        // wrapper has its `$...$` / `$$...$$` rewritten to the new delimiters (see
+        // `swapMathDelimiters` below). Stray `$` outside math wrappers (currency, prose, code)
+        // is invisible to MathJax because `$` is no longer a delimiter.
+        var processedBody = body
         if !self.renderAsCode, !self.mathExtension.isDisabled, let ext = cmark_find_syntax_extension("math"), cmark_syntax_extension_math_get_rendered_count(ext) > 0 {
             s_header += """
 <script type="text/javascript">
@@ -821,12 +822,12 @@ MathJax = {
   tex: {
     // packages: ['base'],        // extensions to use
     inlineMath: [              // start/end delimiter pairs for in-line math
-      ['$', '$']
-      // , ['\\(', '\\)']
+      // ['$', '$']              // disabled to avoid matching currency client-side
+      ['\\(', '\\)']
     ],
     displayMath: [             // start/end delimiter pairs for display math
-      ['$$', '$$']
-      //, ['\\[', '\\]']
+      // ['$$', '$$']
+      ['\\[', '\\]']
     ],
     processEscapes: true,       // use \\$ to produce a literal dollar sign
     processEnvironments: false
@@ -835,13 +836,13 @@ MathJax = {
 </script>
 """
             s_footer += mathExtension.getScriptCode(extraTagLink: "id='MathJax-script' async", extraTagEmbed: "id='MathJax-script'")
+            processedBody = swapMathDelimiters(processedBody)
         }
 
         // Mermaid diagrams support
-        var processedBody = body
-        if !self.renderAsCode, !self.mermaidExtension.isDisabled, body.contains("language-mermaid") {
+        if !self.renderAsCode, !self.mermaidExtension.isDisabled, processedBody.contains("language-mermaid") {
             // Transform mermaid code blocks to mermaid divs
-            processedBody = transformMermaidBlocks(body)
+            processedBody = transformMermaidBlocks(processedBody)
 
             // Inject mermaid.min.js
             s_footer += mermaidExtension.getScriptCode()
@@ -924,6 +925,49 @@ securityLevel: 'strict'
         return "```yaml\n"+text+"```\n"
     }
     
+    /**
+     * Rewrite the inline/display math delimiters inside cmark-extra's `<span class='hl math'>` and
+     * `<div class='hl math'>` wrappers from `$...$` / `$$...$$` to LaTeX-canonical `\(...\)` / `\[...\]`.
+     *
+     * Why: MathJax v3 defaults to `$...$` as an inline delimiter and scans the rendered DOM
+     * client-side, independent of cmark. That re-matches currency pairs like `$1.50 ... $7.89`
+     * as math even though cmark correctly classified them as plain text. Swapping MathJax to
+     * `\(...\)` / `\[...\]` (and rewriting only the spans cmark itself emitted) makes `$`
+     * invisible to MathJax — currency and prose are left alone.
+     *
+     * The trailing `</span>` / `</div>` anchor in each pattern is unforgeable because
+     * `math_ext.c:html_render_math` entity-escapes `<` to `&lt;` inside math content. The
+     * `[^>]*>` allows for any future attributes cmark-extra might add to the open tag (e.g.
+     * `lang="math"` from `CMARK_OPT_GITHUB_PRE_LANG`).
+     */
+    private func swapMathDelimiters(_ html: String) -> String {
+        var result = html
+        // Inline: <span class='hl math'>$...$</span> → <span class='hl math'>\(...\)</span>
+        result = result.replacingOccurrences(
+            of: #"(<span class='hl math'[^>]*>)\$([\s\S]*?)\$(</span>)"#,
+            with: #"$1\\($2\\)$3"#,
+            options: .regularExpression
+        )
+        // Display: <div class='hl math'>$$...$$</div> → <div class='hl math'>\[...\]</div>
+        result = result.replacingOccurrences(
+            of: #"(<div class='hl math'[^>]*>)\$\$([\s\S]*?)\$\$(</div>)"#,
+            with: #"$1\\[$2\\]$3"#,
+            options: .regularExpression
+        )
+        // Defensive: if any math span retained `$...$` (regex miss — e.g., an unforeseen
+        // cmark-extra output variant), log loudly. Under the new MathJax config, an
+        // un-swapped span renders as literal LaTeX source text — silent UX regression.
+        // This converts that silent failure into a loud one for the cost of two
+        // String.range(of:) probes per math-bearing render.
+        if result.range(of: #"<span class='hl math'[^>]*>\$"#, options: .regularExpression) != nil {
+            os_log("math delimiter swap missed an inline span — math may render as literal text. Please report.", log: OSLog.rendering, type: .error)
+        }
+        if result.range(of: #"<div class='hl math'[^>]*>\$\$"#, options: .regularExpression) != nil {
+            os_log("math delimiter swap missed a display block — math may render as literal text. Please report.", log: OSLog.rendering, type: .error)
+        }
+        return result
+    }
+
     /**
      * Transform mermaid code blocks from `<pre...><code class="language-mermaid">...</code></pre>` to `<div class="mermaid">...</div>`.
      */

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -800,7 +800,18 @@ table.debug td {
         }
         css_highlight = formatCSS(css_highlight)
         
-        if !self.renderAsCode, !self.mathExtension.isDisabled, let ext = cmark_find_syntax_extension("math"), cmark_syntax_extension_math_get_rendered_count(ext) > 0 || body.contains("$") {
+        // Gate MathJax injection strictly on whether cmark's math extension actually rendered
+        // a math node. The legacy `|| body.contains("$")` fallback was removed: with the
+        // pandoc-rules fix in cmark-extra/math_ext.c, `rendered_count` is now reliable for
+        // currency-only files. Re-adding the fallback re-introduces the currency-mangling bug
+        // (MathJax v3's `inlineMath: [['$', '$']]` matches `$1.50` pairs client-side regardless
+        // of what cmark did).
+        // KNOWN LIMITATION: mixed files containing BOTH real math (`$x=1$`) and currency (`$100`)
+        // still mangle the currency — MathJax loads for the real math and then re-matches every
+        // `$...$` pair on the page. Fixing that requires either a body post-process to escape
+        // non-math `$` to `\$` (relying on `processEscapes: true` below), or switching cmark-extra
+        // + MathJax to `\(...\)` inline delimiters. Out of scope here.
+        if !self.renderAsCode, !self.mathExtension.isDisabled, let ext = cmark_find_syntax_extension("math"), cmark_syntax_extension_math_get_rendered_count(ext) > 0 {
             s_header += """
 <script type="text/javascript">
 MathJax = {

--- a/cmark-extra/extensions/math_ext.c
+++ b/cmark-extra/extensions/math_ext.c
@@ -120,18 +120,37 @@ static cmark_node *match_inline_math(cmark_syntax_extension *ext, cmark_parser *
     res->start_line = res->end_line = cmark_inline_parser_get_line(inline_parser);
     res->start_column = cmark_inline_parser_get_column(inline_parser) - delims;
     
-    if (punct_before) {
-        right_flanking = false;
+    int can_open, can_close;
+
+    if (delims == 1) {
+        // Pandoc-style rules for inline math ($...$), to avoid false positives on currency:
+        // - Opening $ must be followed by a non-space character.
+        // - Closing $ must be preceded by a non-space character AND not followed by a digit.
+        // This prevents text like "$1,667.84 net ... derived $/hr" from being parsed as math.
+        cmark_chunk *chunk = cmark_inline_parser_get_chunk(inline_parser);
+        unsigned char next_char = (pos + delims < chunk->len) ? chunk->data[pos + delims] : 0;
+        unsigned char prev_char = (pos > 0) ? chunk->data[pos - 1] : 0;
+
+        int next_is_space = (next_char == 0 || next_char == ' ' || next_char == '\t' || next_char == '\n' || next_char == '\r');
+        int prev_is_space = (prev_char == 0 || prev_char == ' ' || prev_char == '\t' || prev_char == '\n' || prev_char == '\r');
+        int next_is_digit = (next_char >= '0' && next_char <= '9');
+
+        can_open  = !next_is_space;
+        can_close = !prev_is_space && !next_is_digit;
+    } else {
+        // Display math ($$...$$): keep the original flanking-based logic.
+        if (punct_before) {
+            right_flanking = false;
+        }
+        if (punct_after) {
+            left_flanking = false;
+        }
+        int not_flanking = !(left_flanking || right_flanking);
+        can_open  = left_flanking  || not_flanking;
+        can_close = right_flanking || not_flanking;
     }
-    if (punct_after) {
-        left_flanking = false;
-    }
-    int not_flanking = !(left_flanking || right_flanking);
-    int can_open  = left_flanking  || not_flanking;
-    int can_close = right_flanking || not_flanking;
-    if (delims == 2 || delims == 1) {
-        cmark_inline_parser_push_delimiter(inline_parser, character, can_open, can_close, res);
-    }
+
+    cmark_inline_parser_push_delimiter(inline_parser, character, can_open, can_close, res);
 
     return res;
 }


### PR DESCRIPTION
## Summary

Fixes #195. The bug had three layers; this PR addresses all three.

### Layer 1 — cmark-extra parse: don't match currency as math
Apply pandoc inline-math flanking rules in `cmark-extra/extensions/math_ext.c`: opening `$` must be followed by a non-space, closing `$` must be preceded by a non-space **and not followed by a digit**. This prevents `$1.50 ... $7.89` from being matched as `$1.50 ... $7.89` (a math span) at parse time.

### Layer 2 — Swift gate: don't load MathJax for currency-only files
`Settings+render.swift` previously gated MathJax injection on `rendered_count > 0 || body.contains("$")`. The `body.contains("$")` fallback caused MathJax to load in the WebView for any document containing `$` — including currency-only documents. Once MathJax loaded with its default config (`inlineMath: [['$', '$']]`), it scanned the DOM client-side and re-matched every dollar pair as math, undoing Layer 1's work for the preview path. Dropped the fallback; `rendered_count` from cmark is now the sole gate.

### Layer 3 — MathJax delimiter swap: handle mixed math + currency
For files that contain **both** real math and currency, Layer 2 isn't enough — `rendered_count > 0` because of the real math, so MathJax still loads, and its `$...$` default delimiters still re-match currency client-side.

This PR's third commit configures MathJax to use the LaTeX-canonical `\(...\)` / `\[...\]` delimiters as the only delimiters, and post-processes the rendered body in Swift (`swapMathDelimiters`) to rewrite the `$...$` / `$$...$$` inside cmark-extra's `<span class='hl math'>` / `<div class='hl math'>` wrappers. Stray `$` outside those wrappers (currency, prose, code) is now invisible to MathJax.

The post-process is in Swift rather than in cmark-extra so the C library's output contract stays stable for any other downstream consumer. The regex uses a `</span>` / `</div>` trailing anchor that cannot be forged from inside math content because `html_render_math` entity-escapes `<` to `&lt;`. A defensive `os_log(.error)` fires if any math span survives the rewrite — silent typesetting failure becomes loud.

### Cosmetic side effect (no functional impact)

Raw HTML output from `qlmarkdown_cli` and the Shortcuts Extension (`MdToHtml_Extension`, `MdToHtmlCode_Extension`) now contains `\(...\)` / `\[...\]` inside `<span class='hl math'>` / `<div class='hl math'>` blocks instead of `$...$` / `$$...$$`. Both render identically under MathJax. WebView consumers (Quick Look preview, in-app preview, share preview) are unaffected visually.

## Test plan

- [x] Currency-only file (no math at all): renders as plain currency. MathJax not loaded.
- [x] Real inline math (`$E=mc^2$`): typesets.
- [x] Display math (`$$\int...$$`): typesets.
- [x] Fenced ` ```math ` block: typesets.
- [x] **Mixed file (real math AND currency in the same document): math typesets AND currency renders as plain text.**
- [x] HTML-special chars inside math (`$a < b$`, `$x > 0$`, `$a \& b$`): all typeset.
- [x] Multiline display math: typesets.
- [x] Two inline math expressions on one line: both typeset independently.
- [x] CLI sanity: `<span class='hl math'>\(E = mc^2\)</span>` and `inlineMath: [['\\(', '\\)']]` both visible in `qlmarkdown_cli` output.
- [x] Verified on live build under macOS Quick Look.