### PR TITLE
Fixed typo in README.md regarding uninstalling the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ After the first execution, the Quick Look extension will be available (and enabl
 
 ## Uninstall
 
-To install the application, simply drag it to the trash.
+To uninstall the application, simply drag it to the trash.
 Support files can be deleted by removing the folder `~/Library/Group Containers/group.org.sbarex.qlmarkdown`.
 
 


### PR DESCRIPTION
The Uninstall section of the README stated:

> To install the application, simply drag it to the...

I fixed it to read:

> To uninstall the application, simply drag it to the...