### PR TITLE
Apply Custom Style in "render as source code" mode

### DIFF
--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -751,12 +751,12 @@ table.debug td {
             return "<style type='text/css'>\(code)\n</style>\n"
         }
             
-        if !self.renderAsCode {
-            let css = (self.customCSSFetched ? self.customCSSCode : self.getCustomCSSCode()) ?? ""
-            css_doc_extended = formatCSS(css)
-            if css_doc_extended.isEmpty || !self.customCSSOverride {
-                css_doc += formatCSS(getBundleContents(forResource: "default", ofType: "css"))
-            }
+        // Custom Style applies in both modes; only the bundled GitHub default.css is
+        // specific to Markdown (non-source) mode.
+        let css = (self.customCSSFetched ? self.customCSSCode : self.getCustomCSSCode()) ?? ""
+        css_doc_extended = formatCSS(css)
+        if !self.renderAsCode, css_doc_extended.isEmpty || !self.customCSSOverride {
+            css_doc += formatCSS(getBundleContents(forResource: "default", ofType: "css"))
         }
             
         var css_highlight: String = ""


### PR DESCRIPTION
Addresses #166.

In "Render as source code" mode the user's **Custom Style** was ignored — it only applied to rendered-Markdown mode, contradicting the README ("custom style … appended after the CSS used for the highlight the source code").

**Cause:** in `getCompleteHTML(...)` the custom CSS (`css_doc_extended`) was computed inside an `if !self.renderAsCode { … }` guard, so it stayed empty in source mode — even though it's unconditionally appended to the final style block (`css_doc + css_highlight + css_doc_extended`).

**Fix:** always compute the custom CSS; keep only the bundled GitHub `default.css` (which is specific to Markdown rendering) behind the `!renderAsCode` guard. ~6-line change in one function.

Verified with `qlmarkdown_cli` and a Custom Style set:

| | render-as-code ON (source) | OFF (markdown) |
|---|---|---|
| before | custom CSS absent | present |
| after | custom CSS present | present |

Markdown mode is unchanged; builds clean.

Scoped to Custom Style. The separate request for a dedicated source-mode syntax-highlight *theme picker* (the existing `// FIXME` in `renderAsSourceCode`) is left as a follow-up.
