### PR TITLE
Fixed qlmarkdown_cli resource lookup when invoked via a symlink.

### DIFF
--- a/qlmarkdown_cli/qlmarkdown_cli.swift
+++ b/qlmarkdown_cli/qlmarkdown_cli.swift
@@ -236,7 +236,8 @@ struct QLMarkdownCLI: ParsableCommand {
         if let app {
             return URL(fileURLWithPath: app)
         } else {
-            return cliUrl.deletingLastPathComponent().deletingLastPathComponent()
+            // Resolve symlinks so resources load when invoked via a Homebrew/`ln -s` link. (#144)
+            return cliUrl.resolvingSymlinksInPath().deletingLastPathComponent().deletingLastPathComponent()
         }
     }
     


### PR DESCRIPTION
Fixes #144.

`qlmarkdown_cli` locates its support resources by walking up from its own
executable path to the app bundle, but it never resolved symlinks. Both the
Homebrew cask (`binary "…/qlmarkdown_cli"`) and the README (`ln -s …`) expose
the CLI through a symlink, so the walk-up landed *outside* the `.app`, the
bundled `highlight` resources (themes, langDefs) were never found, and all
syntax-highlight styling was silently dropped — the reporter's "ERROR FOR
theme themes/acid.theme" / unstyled output.

Resolving the symlink before deriving the bundle path fixes it:

```swift
cliUrl.resolvingSymlinksInPath().deletingLastPathComponent().deletingLastPathComponent()
```

Verified locally with the in-bundle CLI vs. a symlink pointing at it (a code
block rendered with `--syntax-highlight on`):

| invocation | resolved bundle | result |
| --- | --- | --- |
| direct | `…/QLMarkdown.app/Contents` | styled HTML (theme + highlighting) |
| symlink, before | escaped the `.app` | styling dropped |
| symlink, after | `…/QLMarkdown.app/Contents` | byte-for-byte identical to direct |

No change to the direct-invocation path; no new build warnings.
