### PR TITLE
Fixed auto-reload breaking when the file is saved by another app

### DIFF
--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -498,6 +498,7 @@ class ViewController: NSViewController {
     var edited: Bool = false
     var allow_reload: Bool = true
     fileprivate var markdown_source: DispatchSourceFileSystemObject?
+    fileprivate var pendingReload: DispatchWorkItem?
     var markdown_file: URL? {
         didSet {
             if let file = markdown_file {
@@ -865,9 +866,39 @@ class ViewController: NSViewController {
             return
         }
         
-        self.markdown_source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fileDescriptor, eventMask: .all, queue: DispatchQueue.main)
-        self.markdown_source!.setEventHandler { [weak self] in
+        let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fileDescriptor, eventMask: .all, queue: DispatchQueue.main)
+        source.setEventHandler { [weak self] in
             guard let me = self else {
+                return
+            }
+            // Editors usually save by writing a temp file and renaming it over the
+            // original, which replaces the inode this descriptor watches. Drop the
+            // now-stale source and debounce the reload so the new file is in place
+            // before reading it; `reloadMarkdown` re-arms the watch on the new inode.
+            me.markdown_source?.cancel()
+            me.markdown_source = nil
+            me.scheduleReloadFromDisk()
+        }
+        source.setCancelHandler {
+            close(fileDescriptor)
+        }
+        self.markdown_source = source
+        source.resume()
+    }
+
+    /// Reload the source file after an external change. Debounced and retried so the
+    /// brief gap of an atomic save (rename over the original) is not mistaken for the
+    /// file being deleted — which previously left the preview stuck on a load error.
+    private func scheduleReloadFromDisk(retriesLeft: Int = 8) {
+        self.pendingReload?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let me = self, let file = me.markdown_file else {
+                return
+            }
+            guard FileManager.default.fileExists(atPath: file.path) else {
+                if retriesLeft > 0 {
+                    me.scheduleReloadFromDisk(retriesLeft: retriesLeft - 1)
+                }
                 return
             }
             if me.edited {
@@ -881,16 +912,13 @@ class ViewController: NSViewController {
                     me.reloadMarkdown(me)
                 } else {
                     me.allow_reload = false
-                    me.markdown_source?.cancel()
                 }
             } else {
-                self?.reloadMarkdown(me)
+                me.reloadMarkdown(me)
             }
         }
-        self.markdown_source!.setCancelHandler {
-            close(fileDescriptor)
-        }
-        self.markdown_source!.resume()
+        self.pendingReload = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
     }
     
     @IBAction func exportPreview(_ sender: Any) {


### PR DESCRIPTION
Fixes the auto-reload (added in 1.0.15) getting stuck on `** Error loading file … **` with the refresh button greyed out when the open file is edited in another app (#99).

**Cause:** the preview watches the source file with a vnode `DispatchSource` on its *inode*. Editors that save atomically — write a temp file, then rename it over the original (vim, BBEdit, VS Code, …) — replace that inode. The watcher then fires on the now-stale descriptor and reads the path during the brief moment it's empty (→ the load error), and since nothing re-arms the watch on the new inode, later saves are never detected (the stuck / greyed-out state).

**Fix** (`ViewController.swift`): drop the stale source on the event, debounce + retry the reload so the atomic-save gap isn't mistaken for a deletion, and re-arm the watch on the new file via the existing reload path.

Verified in the app with a simulated atomic save (rename-away + recreate): before → "Error loading file" and permanently stuck; after → reloads to the new content and stays armed across repeated saves.

_(The QuickLook **extension** still can't auto-refresh — that's the OS preview-caching limit you noted; this only fixes the standalone app's reload.)_

Addresses #99.
