### PR TITLE
Fixed shell syntax highlighting treating a hyphen inside a path as an option

### DIFF
--- a/Resources/highlight/langDefs/sh.lang
+++ b/Resources/highlight/langDefs/sh.lang
@@ -44,8 +44,10 @@ Keywords={
   { Id=4,
     Regex=[[ \$[\w\#]+ ]],
   },
+  -- \B requires the dash to start a new word so a hyphen inside a path or
+  -- filename (e.g. my-project) is not mistaken for a command option
   { Id=2,
-    Regex=[[ \-\-?[\w\-]+ ]],
+    Regex=[[ \B\-\-?[\w\-]+ ]],
   },
 
   --see OnStateChange


### PR DESCRIPTION
Fixes #71

### Problem

In shell/Bash code blocks, a hyphen **inside** a path or filename is highlighted as if it were a command-line option, even with no whitespace before it. From the issue's example, `vim /some/sub-path.folder/dir` renders `-path` in the option colour.

The Bash option rule matches a `-word` run regardless of what precedes it:

```lua
{ Id=2,
    Regex=[[ \-\-?[\w\-]+ ]],
},
```

So `my-project`, `bin-utils`, `file-name.txt`, `x86-64`, … all get their `-segment` coloured as an option.

### Fix

Prepend `\B` (a not-a-word-boundary assertion) so the dash only opens an option when it actually starts a new word:

```lua
{ Id=2,
    Regex=[[ \B\-\-?[\w\-]+ ]],
},
```

- `ls -la` — the space before `-` is `\W\W` (no word boundary) → `\B` matches → **option stays highlighted**.
- `my-project` — `y-` is `\w\W` (a word boundary) → `\B` fails → **not** treated as an option.

`\B` is zero-width (no capturing group, no consumed characters), and highlight matches keyword regexes against the whole line (`sregex_iterator(line.begin(), line.end(), …)`), so the boundary sees the preceding character. Boost.Xpressive has no lookbehind, so `\B` is the right tool here.

The change is in the bundled `Resources/highlight/langDefs/sh.lang` (the copy QLMarkdown actually ships, which already carries local tweaks), so it needs no `highlight` submodule bump.

### Verification (CLI)

```bash
qlmarkdown_cli --syntax-highlight on file.md
```

on a block containing both hyphenated paths and real options:

```bash
cd /Users/foo/my-project/bin-utils      # -project / -utils no longer options
cat ./some-dir/file-name.txt            # -dir / -name no longer options
ls -la                                  # still an option
grep --color=auto foo                   # still an option
find . -name "*.txt" -type f            # still options
rsync --dry-run --no-perms src dst      # still options
[ -f file ] && [[ -z "$x" ]]            # test flags still options
```

After the fix, every hyphen inside a path/filename renders as plain text while genuine short, long, glued (`-xzvf`) and `--long-with-hyphens` options stay highlighted.
