### PR TITLE
Fix heap buffer overflow when setting the syntax-highlight background color

### DIFF
--- a/cmark-extra/extensions/syntaxhighlight.c
+++ b/cmark-extra/extensions/syntaxhighlight.c
@@ -115,10 +115,7 @@ void cmark_syntax_extension_highlight_set_background_color(cmark_syntax_extensio
         mem->free(settings->background_color);
     }
     if (color) {
-        unsigned long len;
-        len = strlen(color);
-        settings->background_color = mem->calloc(len, sizeof(char));
-        strcpy(settings->background_color, color);
+        settings->background_color = strdup(color);
     } else {
         settings->background_color = NULL;
     }


### PR DESCRIPTION
`cmark_syntax_extension_highlight_set_background_color` allocates the buffer one byte too small and `strcpy`s into it, writing the terminating NUL past the end of the allocation:

```c
len = strlen(color);
settings->background_color = mem->calloc(len, sizeof(char)); // len bytes
strcpy(settings->background_color, color);                   // writes len + 1
```

`mem->calloc(len, 1)` reserves exactly `len` bytes, but `strcpy` copies `len` characters **plus** the trailing NUL — a one-byte heap overflow on every call with a non-empty color (e.g. `"#ffffff"` → 7-byte buffer, 8 bytes written).

The sibling setters in the same file (`set_theme_name`, `set_font_family`) already use `strdup`, which sizes the allocation correctly. This makes the background-color setter consistent with them. The existing `mem->free` on the previous value is unchanged and compatible with `strdup` (cmark's `mem->free` is plain `free`).

Found by code inspection; no behavioural change beyond the fix.
