### PR TITLE
Fix memory leaks in the inline-image, mention and emoji extensions

### DIFF
--- a/cmark-extra/extensions/emoji.c
+++ b/cmark-extra/extensions/emoji.c
@@ -144,10 +144,11 @@ static cmark_node *match(cmark_syntax_extension *self, cmark_parser *parser,
         cmark_inline_parser_set_offset(inline_parser, start + (end - start) + 1);
         cmark_node_set_user_data(node, placeholder);
         cmark_node_set_user_data_free_func(node, free_user_data);
+    } else {
+        // Unknown shortcode: no node took ownership of the placeholder, so free it.
+        parser->mem->free(placeholder);
     }
-    
-    // parser->mem->free(placeholder); // Don't free the placeholder stored inside the node user_data.
-    
+
     return node;
 }
 

--- a/cmark-extra/extensions/inlineimage.c
+++ b/cmark-extra/extensions/inlineimage.c
@@ -427,7 +427,9 @@ static cmark_node *postprocess(cmark_syntax_extension *ext, cmark_parser *parser
             if (encoded != NULL) {
                 cmark_mem *mem = cmark_get_default_mem_allocator();
                 // Replace the original url with the encoded data.
-                cmark_chunk_set_cstr(mem, &node->as.link.title, strdup(url));
+                // cmark_chunk_set_cstr copies its argument, so pass url directly
+                // (a strdup here would be copied and then leaked).
+                cmark_chunk_set_cstr(mem, &node->as.link.title, url);
                 cmark_chunk_set_cstr(mem, &node->as.link.url, encoded);
                 free(encoded);
             }

--- a/cmark-extra/extensions/mention.c
+++ b/cmark-extra/extensions/mention.c
@@ -84,6 +84,9 @@ static int can_contain(cmark_syntax_extension *extension, cmark_node *node,
 
 static void opaque_free(cmark_syntax_extension *self, cmark_mem *mem, cmark_node *node) {
     if (node->type == CMARK_NODE_MENTION) {
+        // The opaque chunk may own a buffer allocated by cmark_chunk_to_cstr when
+        // the mention is rendered; free that before the chunk struct itself.
+        cmark_chunk_free(mem, (cmark_chunk *)node->as.opaque);
         mem->free(node->as.opaque);
     }
 }


### PR DESCRIPTION
Three small memory leaks in the cmark extensions, all found by code inspection. Each leaks per-token on a normal render path — negligible in the one-shot Quick Look process, but they accumulate in `qlmarkdown_cli` and any repeated library use.

**`inlineimage.c` — leak per embedded image.** The original URL is copied into the node title via `strdup`:

```c
cmark_chunk_set_cstr(mem, &node->as.link.title, strdup(url));
```

`cmark_chunk_set_cstr` makes its own copy of the argument — the next line proves it (`set_cstr(…, encoded); free(encoded);`) — so the `strdup`'d string is copied and then orphaned. Pass `url` directly (also avoids the `strdup(NULL)` UB if a title-less image ever reaches here, since `set_cstr` handles `NULL`).

**`mention.c` — leak per rendered `@mention`.** `cmark_node_get_mention_login` calls `cmark_chunk_to_cstr`, which allocates an owned buffer into the opaque chunk (`alloc = 1`). `opaque_free` then frees the `cmark_chunk` struct but not that buffer. Call `cmark_chunk_free` first so the owned data is released (it only frees when `alloc`, so the un-rendered, parser-buffer case stays safe).

**`emoji.c` — leak per unknown `:shortcode:`.** `placeholder` is handed to the node's user data only when a node is created. For an unrecognized shortcode no node is created, so it's never freed. Free it in the `else` branch.

Verified: builds clean, and a CLI run exercising all three paths (local image embed, `@mention`, known + unknown emoji) renders correctly and passes a Guard Malloc run with no double-free / use-after-free. No behavioural change.
