### PR TITLE
Add definition list rendering extension

### DIFF
--- a/QLMarkdown.xcodeproj/project.pbxproj
+++ b/QLMarkdown.xcodeproj/project.pbxproj
@@ -283,6 +283,10 @@
 		83F8822E2598A5C6008C5071 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F8822C2598A5C0008C5071 /* WebKit.framework */; };
 		83F88259259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
 		83F8825A259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		DEF1000000000000000000C1 /* defl.c in Sources */ = {isa = PBXBuildFile; fileRef = DEF1000000000000000000BB /* defl.c */; };
+		DEF1000000000000000000C2 /* defl.c in Sources */ = {isa = PBXBuildFile; fileRef = DEF1000000000000000000BB /* defl.c */; };
+		DEF1000000000000000000C3 /* defl.c in Sources */ = {isa = PBXBuildFile; fileRef = DEF1000000000000000000BB /* defl.c */; };
+		DEF1000000000000000000C4 /* defl.c in Sources */ = {isa = PBXBuildFile; fileRef = DEF1000000000000000000BB /* defl.c */; };
 		83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 		83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 /* End PBXBuildFile section */
@@ -700,6 +704,8 @@
 		83F8822C2598A5C0008C5071 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		83F88257259906C7008C5071 /* heads.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = heads.h; sourceTree = "<group>"; };
 		83F88258259906C7008C5071 /* heads.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = heads.c; sourceTree = "<group>"; };
+		DEF1000000000000000000AA /* defl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = defl.h; sourceTree = "<group>"; };
+		DEF1000000000000000000BB /* defl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = defl.c; sourceTree = "<group>"; };
 		83F8825C25991BFC008C5071 /* heads_utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = heads_utils.cpp; sourceTree = "<group>"; };
 		83F8825D25991BFC008C5071 /* heads_utils.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = heads_utils.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -833,6 +839,8 @@
 				834CAB9A2593650800673002 /* emoji_utils.cpp */,
 				83F88257259906C7008C5071 /* heads.h */,
 				83F88258259906C7008C5071 /* heads.c */,
+				DEF1000000000000000000AA /* defl.h */,
+				DEF1000000000000000000BB /* defl.c */,
 				83F8825C25991BFC008C5071 /* heads_utils.cpp */,
 				83F8825D25991BFC008C5071 /* heads_utils.hpp */,
 				83CF71C72C5FCD780066A195 /* highlight.h */,
@@ -1476,6 +1484,7 @@
 				83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				834A4F5629E8AD8E00692964 /* html.c in Sources */,
 				83F8825A259906C7008C5071 /* heads.c in Sources */,
+				DEF1000000000000000000C4 /* defl.c in Sources */,
 				834A4F5929E8AD8E00692964 /* plugin.c in Sources */,
 				834A4F3E29E8AD8D00692964 /* references.c in Sources */,
 				83720A3925B8EA6600B49FEC /* decode.c in Sources */,
@@ -1555,6 +1564,7 @@
 				8320D5C52D1C3858005868BD /* tasklist.c in Sources */,
 				8320D5DE2D1C3AA7005868BD /* emoji.c in Sources */,
 				8320D5DF2D1C3AA7005868BD /* heads.c in Sources */,
+				DEF1000000000000000000C1 /* defl.c in Sources */,
 				8320D5E02D1C3AA7005868BD /* inlineimage.c in Sources */,
 				8320D5E12D1C3AA7005868BD /* highlight.c in Sources */,
 				8320D5E22D1C3AA7005868BD /* sub_ext.c in Sources */,
@@ -1644,6 +1654,7 @@
 				834A4EF329E8AD8C00692964 /* strikethrough.c in Sources */,
 				83437974271D47DF00A5D6EA /* qlmarkdown_cli.swift in Sources */,
 				8343798D271D4A1900A5D6EA /* heads.c in Sources */,
+				DEF1000000000000000000C2 /* defl.c in Sources */,
 				834A4F8429E92AE800692964 /* extra-extensions.c in Sources */,
 				834A4F1A29E8AD8D00692964 /* blocks.c in Sources */,
 				834A4F0129E8AD8C00692964 /* tagfilter.c in Sources */,
@@ -1663,6 +1674,7 @@
 				83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				83D22E642DCA659C0013EB9D /* Settings+render.swift in Sources */,
 				83F88259259906C7008C5071 /* heads.c in Sources */,
+				DEF1000000000000000000C3 /* defl.c in Sources */,
 				835886B329E960050088DF7D /* math_ext.c in Sources */,
 				836B747D259E2D7B00A6A5F7 /* AboutViewController.swift in Sources */,
 				83327D202593FCEB00E76CF6 /* url.cpp in Sources */,

--- a/QLMarkdown/Base.lproj/Main.storyboard
+++ b/QLMarkdown/Base.lproj/Main.storyboard
@@ -824,6 +824,7 @@
                                                         <gridRow topPadding="8" id="mRf-rL-ZFR"/>
                                                         <gridRow id="6bo-pC-VNr"/>
                                                         <gridRow id="axC-Xg-GDO"/>
+                                                        <gridRow id="dEf-Li-st0"/>
                                                     </rows>
                                                     <columns>
                                                         <gridColumn id="Kw4-iz-WrK"/>
@@ -1591,6 +1592,27 @@
                                                                 </customSpacing>
                                                             </stackView>
                                                         </gridCell>
+                                                        <gridCell row="dEf-Li-st0" column="Kw4-iz-WrK" id="dEf-Li-st1">
+                                                            <button key="contentView" toolTip="Render definition lists (a term line followed by `: description` lines)." horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dEf-Li-st2">
+                                                                <rect key="frame" x="0.0" y="0.0" width="117" height="16"/>
+                                                                <buttonCell key="cell" type="check" title="Definition list" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="dEf-Li-st3">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <binding destination="XfG-lQ-9wD" name="value" keyPath="self.definitionListExtension" id="dEf-Li-st4"/>
+                                                                    <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.renderAsCode" id="dEf-Li-st5">
+                                                                        <dictionary key="options">
+                                                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                        </dictionary>
+                                                                    </binding>
+                                                                </connections>
+                                                            </button>
+                                                        </gridCell>
+                                                        <gridCell row="dEf-Li-st0" column="h9h-fV-gFn" id="dEf-Li-st6"/>
+                                                        <gridCell row="dEf-Li-st0" column="LDl-3O-4gf" id="dEf-Li-st7"/>
+                                                        <gridCell row="dEf-Li-st0" column="Frg-Lu-cBX" id="dEf-Li-st8"/>
+                                                        <gridCell row="dEf-Li-st0" column="EM0-Js-ao5" id="dEf-Li-st9"/>
                                                     </gridCells>
                                                 </gridView>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ccb-oe-cYh">

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -214,7 +214,16 @@ extension Settings {
                 os_log("Could not enable markdown `heads` extension!", log: OSLog.rendering, type: .error)
             }
         }
-        
+
+        if self.definitionListExtension {
+            if let ext = cmark_find_syntax_extension("definitionlist") {
+                cmark_parser_attach_syntax_extension(parser, ext)
+                os_log("Enabled markdown `definitionlist` extension.", log: OSLog.rendering, type: .debug)
+            } else {
+                os_log("Could not enable markdown `definitionlist` extension!", log: OSLog.rendering, type: .error)
+            }
+        }
+
         if self.highlightExtension {
             if let ext = cmark_find_syntax_extension("highlight") {
                 cmark_parser_attach_syntax_extension(parser, ext)

--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -242,6 +242,7 @@ class Settings: Codable {
         case autoLinkExtension
         case checkboxExtension
         case headsExtension
+        case definitionListExtension
         case hightlightExtension
         case inlineImageExtension
         case mathExtension
@@ -470,6 +471,7 @@ class Settings: Codable {
     var autoLinkExtension: Bool = true
     var checkboxExtension: Bool = false
     var headsExtension: Bool = true
+    var definitionListExtension: Bool = false
     var highlightExtension: Bool = false
     var inlineImageExtension: Bool = true
     var mathExtension: JSExtension = .link(url: nil)
@@ -550,6 +552,7 @@ class Settings: Codable {
         self.mentionExtension = try container.decode(Bool.self, forKey:.mentionExtension)
         self.checkboxExtension = try container.decode(Bool.self, forKey:.checkboxExtension)
         self.headsExtension = try container.decode(Bool.self, forKey:.headsExtension)
+        self.definitionListExtension = try container.decodeIfPresent(Bool.self, forKey: .definitionListExtension) ?? false
         self.highlightExtension = try container.decode(Bool.self, forKey: .hightlightExtension)
        
         self.syntaxHighlightExtension = try container.decode(Bool.self, forKey: .syntaxHighlightExtension)
@@ -627,6 +630,7 @@ class Settings: Codable {
         try container.encode(self.mentionExtension, forKey: .mentionExtension)
         try container.encode(self.checkboxExtension, forKey: .checkboxExtension)
         try container.encode(self.headsExtension, forKey: .headsExtension)
+        try container.encode(self.definitionListExtension, forKey: .definitionListExtension)
         try container.encode(self.highlightExtension, forKey: .hightlightExtension)
         
         try container.encode(self.syntaxHighlightExtension, forKey: .syntaxHighlightExtension)
@@ -719,7 +723,8 @@ class Settings: Codable {
         self.mentionExtension = s.mentionExtension
         self.checkboxExtension = s.checkboxExtension
         self.headsExtension = s.headsExtension
-        
+        self.definitionListExtension = s.definitionListExtension
+
         self.highlightExtension = s.highlightExtension
         
         self.syntaxHighlightExtension = s.syntaxHighlightExtension
@@ -799,6 +804,9 @@ class Settings: Codable {
         }
         if let ext = defaultsDomain[Self.CodingKeys.headsExtension.rawValue] as? Bool {
             headsExtension = ext
+        }
+        if let ext = defaultsDomain[Self.CodingKeys.definitionListExtension.rawValue] as? Bool {
+            definitionListExtension = ext
         }
         
         if let ext = defaultsDomain[Self.CodingKeys.hightlightExtension.rawValue] as? Bool {

--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -79,7 +79,14 @@ class ViewController: NSViewController {
             isDirty = true
         }
     }
-    
+
+    @objc dynamic var definitionListExtension: Bool = Settings.factorySettings.definitionListExtension {
+        didSet {
+            guard oldValue != definitionListExtension else { return }
+            isDirty = true
+        }
+    }
+
     @objc dynamic var syntaxHighlightExtension: Bool = Settings.factorySettings.syntaxHighlightExtension {
         didSet {
             guard oldValue != syntaxHighlightExtension else { return }
@@ -1357,6 +1364,7 @@ document.addEventListener('scroll', function(e) {
         self.mermaidExtensionEmbed = settings.mermaidExtension.getMode()?.embed ?? false
         
         self.mentionExtension = settings.mentionExtension
+        self.definitionListExtension = settings.definitionListExtension
         self.syntaxHighlightExtension = settings.syntaxHighlightExtension
         
         self.emojiExtension = settings.emojiExtension != .disabled
@@ -1418,6 +1426,7 @@ document.addEventListener('scroll', function(e) {
         settings.mathExtension = self.mathExtension ? (self.mathExtensionEmbed ? .embed(url: nil) : .link(url: nil)) : .disabled
         settings.mermaidExtension = self.mermaidExtension ? (self.mermaidExtensionEmbed ? .embed(url: nil) : .link(url: nil)) : .disabled
         settings.mentionExtension = self.mentionExtension
+        settings.definitionListExtension = self.definitionListExtension
 
         settings.emojiExtension = self.emojiExtension ? (self.emojiImageOption ? .images : .font) : .disabled
         

--- a/cmark-extra/extensions/defl.c
+++ b/cmark-extra/extensions/defl.c
@@ -1,0 +1,189 @@
+//
+//  defl.c
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+
+#include "defl.h"
+
+#include <stdint.h>
+
+#include "../../cmark-gfm/src/parser.h"
+#include "../../cmark-gfm/src/render.h"
+#include "../../cmark-gfm/src/html.h"
+
+// cmark-gfm has no native definition lists. This post-process extension
+// rewrites the compact `term` / `: description` syntax (no blank line between
+// the lines) into <dl>/<dt>/<dd>, moving the parsed inlines into the new nodes
+// so markup in terms and descriptions is preserved.
+
+typedef enum {
+    DEFL_LIST = 1,
+    DEFL_TERM,
+    DEFL_DESCRIPTION,
+} defl_kind;
+
+// The list wrapper is a CMARK_NODE_CUSTOM_BLOCK; the term and description are
+// paragraphs so their moved inline children (links, emphasis, …) sit in the
+// inline container cmark's renderer expects. Each is tagged so html_render
+// emits <dl>/<dt>/<dd> instead of the node's default markup.
+static cmark_node *make_node(cmark_mem *mem, cmark_syntax_extension *ext, cmark_node_type type, defl_kind kind) {
+    cmark_node *node = cmark_node_new_with_mem_and_ext(type, mem, ext);
+    cmark_node_set_user_data(node, (void *)(intptr_t)kind);
+    return node;
+}
+
+static int is_definition_list(cmark_syntax_extension *ext, cmark_node *node) {
+    return node && node->extension == ext &&
+           (defl_kind)(intptr_t)cmark_node_get_user_data(node) == DEFL_LIST;
+}
+
+// A description line is a text node whose content begins with the ':' marker.
+static int starts_description(cmark_node *line) {
+    if (!line || line->type != CMARK_NODE_TEXT) {
+        return 0;
+    }
+    const char *text = cmark_node_get_literal(line);
+    return text != NULL && text[0] == ':';
+}
+
+// Count the `: …` description lines in a paragraph, or 0 when it is not a
+// definition list: it must have a non-empty term and every line after the
+// first must be a description.
+static int count_descriptions(cmark_node *para) {
+    cmark_node *child = cmark_node_first_child(para);
+    if (!child || child->type == CMARK_NODE_SOFTBREAK) {
+        return 0;
+    }
+    int count = 0;
+    for (; child; child = cmark_node_next(child)) {
+        if (child->type != CMARK_NODE_SOFTBREAK) {
+            continue;
+        }
+        if (!starts_description(cmark_node_next(child))) {
+            return 0;
+        }
+        count++;
+    }
+    return count;
+}
+
+// Drop the ':' marker (and one optional following space) from a description's
+// leading text node.
+static void strip_marker(cmark_node *text) {
+    const char *literal = cmark_node_get_literal(text);
+    if (!literal || literal[0] != ':') {
+        return;
+    }
+    const char *rest = literal + 1; // skip ':'
+    if (*rest == ' ') {
+        rest++;
+    }
+    // set_literal copies rest into a new buffer before freeing the old one, so
+    // passing a pointer into the node's own literal is safe.
+    cmark_node_set_literal(text, rest);
+}
+
+// Move inlines starting at *cursor into dest until a soft break (or the end),
+// leaving *cursor on that soft break (or NULL).
+static void move_line(cmark_node **cursor, cmark_node *dest) {
+    cmark_node *node = *cursor;
+    while (node && node->type != CMARK_NODE_SOFTBREAK) {
+        cmark_node *next = cmark_node_next(node);
+        cmark_node_unlink(node);
+        cmark_node_append_child(dest, node);
+        node = next;
+    }
+    *cursor = node;
+}
+
+static void convert_paragraph(cmark_syntax_extension *ext, cmark_mem *mem, cmark_node *para) {
+    // Merge into the immediately preceding definition list, when there is one,
+    // so consecutive term/description paragraphs form a single <dl>.
+    cmark_node *prev = cmark_node_previous(para);
+    cmark_node *list = is_definition_list(ext, prev) ? prev : NULL;
+    if (!list) {
+        list = make_node(mem, ext, CMARK_NODE_CUSTOM_BLOCK, DEFL_LIST);
+        cmark_node_insert_before(para, list);
+    }
+
+    // Reuse `para` as the <dt>: it keeps the term inlines (everything before the
+    // first soft break) and, by staying in the tree, keeps its content buffer
+    // alive — that buffer backs the literal of every inline, including the ones
+    // moved into the <dd> nodes below, so freeing it would dangle them.
+    cmark_node *cursor = cmark_node_first_child(para);
+    while (cursor && cursor->type != CMARK_NODE_SOFTBREAK) {
+        cursor = cmark_node_next(cursor);
+    }
+    cmark_node_unlink(para);
+    cmark_node_set_syntax_extension(para, ext);
+    cmark_node_set_user_data(para, (void *)(intptr_t)DEFL_TERM);
+    cmark_node_append_child(list, para);
+
+    while (cursor) { // cursor is the soft break before a description line
+        cmark_node *separator = cursor;
+        cursor = cmark_node_next(cursor);
+        cmark_node_unlink(separator);
+        cmark_node_free(separator);
+
+        if (cursor) {
+            strip_marker(cursor);
+        }
+        cmark_node *description = make_node(mem, ext, CMARK_NODE_PARAGRAPH, DEFL_DESCRIPTION);
+        move_line(&cursor, description);
+        cmark_node_append_child(list, description);
+    }
+}
+
+static void process_children(cmark_syntax_extension *ext, cmark_mem *mem, cmark_node *parent) {
+    cmark_node *child = cmark_node_first_child(parent);
+    while (child) {
+        cmark_node *next = cmark_node_next(child); // capture before child may be unlinked
+        if (child->type == CMARK_NODE_PARAGRAPH) {
+            if (count_descriptions(child) > 0) {
+                convert_paragraph(ext, mem, child);
+            }
+        } else if (child->type == CMARK_NODE_BLOCK_QUOTE) {
+            process_children(ext, mem, child);
+        }
+        child = next;
+    }
+}
+
+static cmark_node *postprocess(cmark_syntax_extension *ext, cmark_parser *parser, cmark_node *root) {
+    cmark_consolidate_text_nodes(root);
+    process_children(ext, parser->mem, root);
+    return root;
+}
+
+static void html_render(cmark_syntax_extension *extension,
+                        struct cmark_html_renderer *renderer,
+                        cmark_node *node,
+                        cmark_event_type ev_type,
+                        int options) {
+    cmark_strbuf *html = renderer->html;
+    int entering = ev_type == CMARK_EVENT_ENTER;
+
+    switch ((defl_kind)(intptr_t)cmark_node_get_user_data(node)) {
+    case DEFL_LIST:
+        cmark_html_render_cr(html);
+        cmark_strbuf_puts(html, entering ? "<dl>\n" : "</dl>\n");
+        break;
+    case DEFL_TERM:
+        cmark_strbuf_puts(html, entering ? "<dt>" : "</dt>\n");
+        break;
+    case DEFL_DESCRIPTION:
+        cmark_strbuf_puts(html, entering ? "<dd>" : "</dd>\n");
+        break;
+    }
+}
+
+cmark_syntax_extension *create_definitionlist_extension(void) {
+    cmark_syntax_extension *ext = cmark_syntax_extension_new("definitionlist");
+
+    cmark_syntax_extension_set_postprocess_func(ext, postprocess);
+    cmark_syntax_extension_set_html_render_func(ext, html_render);
+
+    return ext;
+}

--- a/cmark-extra/extensions/defl.h
+++ b/cmark-extra/extensions/defl.h
@@ -1,0 +1,15 @@
+//
+//  defl.h
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+
+#ifndef defl_h
+#define defl_h
+
+#include "cmark-gfm-core-extensions.h"
+
+cmark_syntax_extension *create_definitionlist_extension(void);
+
+#endif /* defl_h */

--- a/cmark-extra/extensions/extra-extensions.c
+++ b/cmark-extra/extensions/extra-extensions.c
@@ -17,6 +17,7 @@
 #include "inlineimage.h"
 #include "emoji.h"
 #include "heads.h"
+#include "defl.h"
 #include "highlight.h"
 #include "math_ext.h"
 #include "sub_ext.h"
@@ -31,6 +32,7 @@ static int extra_extensions_registration(cmark_plugin *plugin) {
 
     cmark_plugin_register_syntax_extension(plugin, create_emoji_extension());
     cmark_plugin_register_syntax_extension(plugin, create_heads_extension());
+    cmark_plugin_register_syntax_extension(plugin, create_definitionlist_extension());
     cmark_plugin_register_syntax_extension(plugin, create_highlight_extension());
     cmark_plugin_register_syntax_extension(plugin, create_math_extension());
     cmark_plugin_register_syntax_extension(plugin, create_sup_extension());

--- a/examples/test-definition-list.md
+++ b/examples/test-definition-list.md
@@ -1,0 +1,41 @@
+# Definition List Test
+
+This file tests definition-list rendering (the `definitionlist` extension): a term
+line immediately followed by one or more `: description` lines.
+
+## Basic
+
+Apple
+: Pomaceous fruit of plants of the genus *Malus*.
+
+Orange
+: A citrus fruit, usually orange in colour.
+
+## Multiple descriptions
+
+Markdown
+: A lightweight markup language with plain-text formatting syntax.
+: Created by John Gruber in 2004.
+
+## Inline markup
+
+**HTML**
+: The standard markup language for web pages — it can contain `code`, *emphasis*, and [links](https://example.com).
+
+## Inside a blockquote
+
+> Quoted term
+> : Definition lists also work inside blockquotes.
+
+## Not a definition list
+
+A normal sentence that ends with a colon:
+this following line is ordinary text, so the block stays a paragraph.
+
+## Regular Markdown Content
+
+Regular content renders normally alongside definition lists:
+
+- Item 1
+- Item 2
+- Item 3

--- a/examples/test1.md
+++ b/examples/test1.md
@@ -15,6 +15,7 @@ The previous block placed at the top of the document, starting with `---` and en
 
 - [Extensions](#extensions)
   - [Autolink extension](#autolink-extension)
+  - [Definition list extension](#definition-list-extension)
   - [Emoji extension](#emoji-extension)
   - [GitHub mentions extension](#github-mentions-extension)
   - [Heads extension](#heads-extension)
@@ -37,6 +38,20 @@ The previous block placed at the top of the document, starting with `---` and en
 ## Autolink extension
 
 If the `autolink` extension is enabled the URL https://www.github.com is displayed as a link.
+
+## Definition list extension
+
+With the `definitionlist` extension a term followed by one or more `: description` lines is rendered as a definition list:
+
+Apple
+: Pomaceous fruit of plants of the genus *Malus*.
+
+Markdown
+: A lightweight markup language with plain-text formatting syntax.
+: Created by John Gruber in 2004.
+
+HTML
+: The standard markup language for documents designed to be displayed in a web browser. It can contain `code`, *emphasis*, and [links](https://example.com).
 
 ## Emoji extension
 

--- a/qlmarkdown_cli/qlmarkdown_cli.swift
+++ b/qlmarkdown_cli/qlmarkdown_cli.swift
@@ -143,7 +143,10 @@ struct ExtensionsOptions: ParsableArguments {
     
     @Option(help: ArgumentHelp("Create anchors for the heads.", valueName: "on|off"))
     var headsAnchor: BoolArgumentEnum? = nil
-    
+
+    @Option(help: ArgumentHelp("Render definition lists.", valueName: "on|off"))
+    var definitionList: BoolArgumentEnum? = nil
+
     @Option(help: ArgumentHelp("Highlight text marked with `==`.", valueName: "on|off"))
     var highlight: BoolArgumentEnum? = nil
     
@@ -310,6 +313,9 @@ struct QLMarkdownCLI: ParsableCommand {
         if let o = extensions.headsAnchor {
             settings.headsExtension = o == .on
         }
+        if let o = extensions.definitionList {
+            settings.definitionListExtension = o == .on
+        }
         if let o = extensions.highlight {
             settings.highlightExtension = o == .on
         }
@@ -418,6 +424,7 @@ struct QLMarkdownCLI: ParsableCommand {
         }
         print("    --github-mentions: \(settings.mentionExtension ? "on" : "off")")
         print("    --heads-anchor: \(settings.headsExtension ? "on" : "off")")
+        print("    --definition-list: \(settings.definitionListExtension ? "on" : "off")")
         print("    --highlight: \(settings.highlightExtension ? "on" : "off")")
         print("    --inline-images: \(settings.inlineImageExtension ? "on" : "off")")
         switch settings.mathExtension {


### PR DESCRIPTION
Adds support for definition lists (closes #66). cmark-gfm has no native definition lists, so this is a post-process `cmark-extra` extension (`defl.c`), in the same style as the existing `heads` / `inlineimage` extensions — the cmark engine itself is untouched.

A term on its own line followed by one or more `: description` lines is rewritten into `<dl>`/`<dt>`/`<dd>`:

```md
Apple
: Pomaceous fruit of plants of the genus *Malus*.

Markdown
: A lightweight markup language.
: Created by John Gruber in 2004.
```

→

```html
<dl>
<dt>Apple</dt>
<dd>Pomaceous fruit of plants of the genus <em>Malus</em>.</dd>
<dt>Markdown</dt>
<dd>A lightweight markup language.</dd>
<dd>Created by John Gruber in 2004.</dd>
</dl>
```

Multiple terms in one list and one or more definitions per term are supported, matching the [Markdown Guide](https://www.markdownguide.org/extended-syntax/#definition-lists).

### Behaviour

- **Off by default.** Inline markup in terms and descriptions is preserved (the parsed inlines are moved into the new nodes rather than re-parsed), and it works inside blockquotes.
- A `:` line only starts a description when it directly follows a term line, so ordinary paragraphs that happen to contain a colon are unaffected.
- The bundled `default.css` already styles `dl`/`dt`/`dd`, so no CSS change is needed.

### How it's exposed

- **Preferences UI** — a new **"Definition list" checkbox** in the Extensions grid, wired with bindings exactly like the other extension toggles (value → `definitionListExtension`, enabled → `renderAsCode` via `NSNegateBoolean`).
- **CLI** — a `--definition-list on|off` option.
- **Settings** — a `definitionListExtension` flag (`Codable` + app-group defaults), defaulting to off.

### Examples

- Adds `examples/test-definition-list.md` (basic, multiple-descriptions, inline-markup, and blockquote cases).
- Enriches `examples/test1.md` — the file shown in the **Settings live preview** — with a "Definition list extension" section (Apple / Markdown / HTML) and its TOC entry, so the effect is visible the moment the checkbox is toggled.

### Changed files

- `cmark-extra/extensions/defl.{c,h}`, `extra-extensions.c` — the extension and its registration
- `QLMarkdown/Settings.swift`, `Settings+render.swift` — the flag and render wiring
- `qlmarkdown_cli/qlmarkdown_cli.swift` — the CLI option
- `QLMarkdown/ViewController.swift`, `Base.lproj/Main.storyboard` — the Preferences checkbox
- `examples/test-definition-list.md`, `examples/test1.md` — examples

| Light | Dark |
|---|---|
| ![light](https://s.soreavis.com/SCR-20260628-h5np.png) | ![dark](https://s.soreavis.com/SCR-20260628-h5jp.png) |

Closes #66.
