### PR TITLE
Add GitHub Alerts extension

### DIFF
--- a/QLMarkdown.xcodeproj/project.pbxproj
+++ b/QLMarkdown.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		8320D5DD2D1C3A87005868BD /* MIMEtype.c in Sources */ = {isa = PBXBuildFile; fileRef = 83327D2E2594066300E76CF6 /* MIMEtype.c */; };
 		8320D5DE2D1C3AA7005868BD /* emoji.c in Sources */ = {isa = PBXBuildFile; fileRef = 83EF95222585476800B56FA3 /* emoji.c */; };
 		8320D5DF2D1C3AA7005868BD /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		4034D2FA758A4624A85FE826 /* alert.c in Sources */ = {isa = PBXBuildFile; fileRef = 376A8FF7F19F47B3AD9B463D /* alert.c */; };
 		8320D5E02D1C3AA7005868BD /* inlineimage.c in Sources */ = {isa = PBXBuildFile; fileRef = 83760300258C1813004799ED /* inlineimage.c */; };
 		8320D5E12D1C3AA7005868BD /* highlight.c in Sources */ = {isa = PBXBuildFile; fileRef = 83CF71C82C5FCD780066A195 /* highlight.c */; };
 		8320D5E22D1C3AA7005868BD /* sub_ext.c in Sources */ = {isa = PBXBuildFile; fileRef = 83CF71D22C60053A0066A195 /* sub_ext.c */; };
@@ -102,6 +103,7 @@
 		83437988271D4A1900A5D6EA /* checkbox.c in Sources */ = {isa = PBXBuildFile; fileRef = 838109C625840429000AFE3C /* checkbox.c */; };
 		83437989271D4A1900A5D6EA /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 		8343798D271D4A1900A5D6EA /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		C4C0544E70714CFDB88BD53D /* alert.c in Sources */ = {isa = PBXBuildFile; fileRef = 376A8FF7F19F47B3AD9B463D /* alert.c */; };
 		8343798F271D4A1900A5D6EA /* emoji.c in Sources */ = {isa = PBXBuildFile; fileRef = 83EF95222585476800B56FA3 /* emoji.c */; };
 		83437990271D4A1900A5D6EA /* syntaxhighlight.c in Sources */ = {isa = PBXBuildFile; fileRef = 83598EF525818BCB004664D3 /* syntaxhighlight.c */; };
 		83437992271D4A1900A5D6EA /* emoji_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 834CAB9A2593650800673002 /* emoji_utils.cpp */; };
@@ -282,7 +284,9 @@
 		83F8822D2598A5C0008C5071 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F8822C2598A5C0008C5071 /* WebKit.framework */; };
 		83F8822E2598A5C6008C5071 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F8822C2598A5C0008C5071 /* WebKit.framework */; };
 		83F88259259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		65D0637D19484B8CAF9BA328 /* alert.c in Sources */ = {isa = PBXBuildFile; fileRef = 376A8FF7F19F47B3AD9B463D /* alert.c */; };
 		83F8825A259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		B8E64117F8D84B61BC777EDF /* alert.c in Sources */ = {isa = PBXBuildFile; fileRef = 376A8FF7F19F47B3AD9B463D /* alert.c */; };
 		83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 		83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 /* End PBXBuildFile section */
@@ -700,6 +704,8 @@
 		83F8822C2598A5C0008C5071 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		83F88257259906C7008C5071 /* heads.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = heads.h; sourceTree = "<group>"; };
 		83F88258259906C7008C5071 /* heads.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = heads.c; sourceTree = "<group>"; };
+		B0A7BA4039614C61A365D9CD /* alert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = alert.h; sourceTree = "<group>"; };
+		376A8FF7F19F47B3AD9B463D /* alert.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = alert.c; sourceTree = "<group>"; };
 		83F8825C25991BFC008C5071 /* heads_utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = heads_utils.cpp; sourceTree = "<group>"; };
 		83F8825D25991BFC008C5071 /* heads_utils.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = heads_utils.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -833,6 +839,8 @@
 				834CAB9A2593650800673002 /* emoji_utils.cpp */,
 				83F88257259906C7008C5071 /* heads.h */,
 				83F88258259906C7008C5071 /* heads.c */,
+				B0A7BA4039614C61A365D9CD /* alert.h */,
+				376A8FF7F19F47B3AD9B463D /* alert.c */,
 				83F8825C25991BFC008C5071 /* heads_utils.cpp */,
 				83F8825D25991BFC008C5071 /* heads_utils.hpp */,
 				83CF71C72C5FCD780066A195 /* highlight.h */,
@@ -1476,6 +1484,7 @@
 				83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				834A4F5629E8AD8E00692964 /* html.c in Sources */,
 				83F8825A259906C7008C5071 /* heads.c in Sources */,
+				B8E64117F8D84B61BC777EDF /* alert.c in Sources */,
 				834A4F5929E8AD8E00692964 /* plugin.c in Sources */,
 				834A4F3E29E8AD8D00692964 /* references.c in Sources */,
 				83720A3925B8EA6600B49FEC /* decode.c in Sources */,
@@ -1555,6 +1564,7 @@
 				8320D5C52D1C3858005868BD /* tasklist.c in Sources */,
 				8320D5DE2D1C3AA7005868BD /* emoji.c in Sources */,
 				8320D5DF2D1C3AA7005868BD /* heads.c in Sources */,
+				4034D2FA758A4624A85FE826 /* alert.c in Sources */,
 				8320D5E02D1C3AA7005868BD /* inlineimage.c in Sources */,
 				8320D5E12D1C3AA7005868BD /* highlight.c in Sources */,
 				8320D5E22D1C3AA7005868BD /* sub_ext.c in Sources */,
@@ -1644,6 +1654,7 @@
 				834A4EF329E8AD8C00692964 /* strikethrough.c in Sources */,
 				83437974271D47DF00A5D6EA /* qlmarkdown_cli.swift in Sources */,
 				8343798D271D4A1900A5D6EA /* heads.c in Sources */,
+				C4C0544E70714CFDB88BD53D /* alert.c in Sources */,
 				834A4F8429E92AE800692964 /* extra-extensions.c in Sources */,
 				834A4F1A29E8AD8D00692964 /* blocks.c in Sources */,
 				834A4F0129E8AD8C00692964 /* tagfilter.c in Sources */,
@@ -1663,6 +1674,7 @@
 				83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				83D22E642DCA659C0013EB9D /* Settings+render.swift in Sources */,
 				83F88259259906C7008C5071 /* heads.c in Sources */,
+				65D0637D19484B8CAF9BA328 /* alert.c in Sources */,
 				835886B329E960050088DF7D /* math_ext.c in Sources */,
 				836B747D259E2D7B00A6A5F7 /* AboutViewController.swift in Sources */,
 				83327D202593FCEB00E76CF6 /* url.cpp in Sources */,

--- a/QLMarkdown/Base.lproj/Main.storyboard
+++ b/QLMarkdown/Base.lproj/Main.storyboard
@@ -824,6 +824,7 @@
                                                         <gridRow topPadding="8" id="mRf-rL-ZFR"/>
                                                         <gridRow id="6bo-pC-VNr"/>
                                                         <gridRow id="axC-Xg-GDO"/>
+                                                        <gridRow id="alt-Rw-grd"/>
                                                     </rows>
                                                     <columns>
                                                         <gridColumn id="Kw4-iz-WrK"/>
@@ -1591,6 +1592,27 @@
                                                                 </customSpacing>
                                                             </stackView>
                                                         </gridCell>
+                                                        <gridCell row="alt-Rw-grd" column="Kw4-iz-WrK" id="alt-C0-cel">
+                                                            <button key="contentView" toolTip="GitHub-style alerts ([!NOTE], [!TIP], [!IMPORTANT], [!WARNING], [!CAUTION]) rendered as colored callouts." horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="alt-Bt-btn">
+                                                                <rect key="frame" x="0.0" y="0.0" width="117" height="16"/>
+                                                                <buttonCell key="cell" type="check" title="GitHub alert" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="alt-Bc-cel">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <binding destination="XfG-lQ-9wD" name="value" keyPath="self.alertExtension" id="alt-Vb-bnd"/>
+                                                                    <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.renderAsCode" id="alt-Eb-bnd">
+                                                                        <dictionary key="options">
+                                                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                        </dictionary>
+                                                                    </binding>
+                                                                </connections>
+                                                            </button>
+                                                        </gridCell>
+                                                        <gridCell row="alt-Rw-grd" column="h9h-fV-gFn" id="alt-C1-cel"/>
+                                                        <gridCell row="alt-Rw-grd" column="LDl-3O-4gf" id="alt-C2-cel"/>
+                                                        <gridCell row="alt-Rw-grd" column="Frg-Lu-cBX" id="alt-C3-cel"/>
+                                                        <gridCell row="alt-Rw-grd" column="EM0-Js-ao5" id="alt-C4-cel"/>
                                                     </gridCells>
                                                 </gridView>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ccb-oe-cYh">

--- a/QLMarkdown/Settings+ext.swift
+++ b/QLMarkdown/Settings+ext.swift
@@ -213,6 +213,7 @@ extension Settings {
         
         defaults.set(subExtension, forKey: Self.CodingKeys.subExtension.rawValue)
         defaults.set(supExtension, forKey: Self.CodingKeys.supExtension.rawValue)
+        defaults.set(alertExtension, forKey: Self.CodingKeys.alertExtension.rawValue)
         
         defaults.set(emojiExtension.rawValue, forKey: Self.CodingKeys.emojiExtension.rawValue)
         

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -240,6 +240,19 @@ extension Settings {
                 os_log("Could not enable markdown `sub` extension!", log: OSLog.rendering, type: .error)
             }
         }
+
+        if self.alertExtension {
+            if let ext = cmark_find_syntax_extension("alert") {
+                cmark_parser_attach_syntax_extension(parser, ext)
+
+                os_log(
+                    "Enabled markdown `alert` extension.",
+                    log: OSLog.rendering,
+                    type: .debug)
+            } else {
+                os_log("Could not enable markdown `alert` extension!", log: OSLog.rendering, type: .error)
+            }
+        }
         
         if self.supExtension {
             if let ext = cmark_find_syntax_extension("sup") {
@@ -688,6 +701,13 @@ table.debug td {
         html_debug += "<tr><td>sup extension</td><td>"
         if self.supExtension {
             html_debug += "on " + (cmark_find_syntax_extension("sup") == nil ? " (NOT AVAILABLE" : "")
+        } else {
+            html_debug += "off"
+        }
+        html_debug += "</td></tr>\n"
+        html_debug += "<tr><td>alert extension</td><td>"
+        if self.alertExtension {
+            html_debug += "on " + (cmark_find_syntax_extension("alert") == nil ? " (NOT AVAILABLE" : "")
         } else {
             html_debug += "off"
         }

--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -249,6 +249,7 @@ class Settings: Codable {
         case mentionExtension
         case subExtension
         case supExtension
+        case alertExtension
         case tableExtension
         case tagFilterExtension
         case taskListExtension
@@ -477,6 +478,7 @@ class Settings: Codable {
     var mentionExtension: Bool = false
     var subExtension: Bool = false
     var supExtension: Bool = false
+    var alertExtension: Bool = false
     var tableExtension: Bool = true
     var tagFilterExtension: Bool = true
     var taskListExtension: Bool = true
@@ -559,6 +561,7 @@ class Settings: Codable {
         
         self.subExtension = try container.decode(Bool.self, forKey:.subExtension)
         self.supExtension = try container.decode(Bool.self, forKey:.supExtension)
+        self.alertExtension = try container.decodeIfPresent(Bool.self, forKey:.alertExtension) ?? false
         
         self.emojiExtension = try container.decode(EmojiMode.self, forKey:.emojiExtension)
         
@@ -636,6 +639,7 @@ class Settings: Codable {
         
         try container.encode(self.subExtension, forKey: .subExtension)
         try container.encode(self.supExtension, forKey: .supExtension)
+        try container.encode(self.alertExtension, forKey: .alertExtension)
         
         try container.encode(self.emojiExtension, forKey: .emojiExtension)
         
@@ -729,6 +733,7 @@ class Settings: Codable {
         
         self.subExtension = s.subExtension
         self.supExtension = s.supExtension
+        self.alertExtension = s.alertExtension
         
         self.emojiExtension = s.emojiExtension
         
@@ -824,6 +829,9 @@ class Settings: Codable {
         }
         if let ext = defaultsDomain[Self.CodingKeys.subExtension.rawValue] as? Bool {
             supExtension = ext
+        }
+        if let ext = defaultsDomain[Self.CodingKeys.alertExtension.rawValue] as? Bool {
+            alertExtension = ext
         }
         
         if let n = defaultsDomain[Self.CodingKeys.emojiExtension.rawValue] as? Int, let ext = EmojiMode(rawValue: n) {

--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -161,6 +161,13 @@ class ViewController: NSViewController {
         }
     }
     
+    @objc dynamic var alertExtension: Bool = Settings.factorySettings.alertExtension {
+        didSet {
+            guard oldValue != alertExtension else { return }
+            isDirty = true
+        }
+    }
+
     @objc dynamic var emojiExtension: Bool = Settings.factorySettings.emojiExtension != .disabled {
         didSet {
             guard oldValue != emojiExtension else { return }
@@ -1366,6 +1373,7 @@ document.addEventListener('scroll', function(e) {
         self.highlightExtension = settings.highlightExtension
         self.inlineImageExtension = settings.inlineImageExtension
         self.subSuperScriptExtension = settings.supExtension
+        self.alertExtension = settings.alertExtension
         
         self.hardBreakOption = settings.hardBreakOption
         self.noSoftBreakOption = settings.noSoftBreakOption
@@ -1426,6 +1434,7 @@ document.addEventListener('scroll', function(e) {
         settings.inlineImageExtension = self.inlineImageExtension
         settings.subExtension = self.subSuperScriptExtension
         settings.supExtension = self.subSuperScriptExtension
+        settings.alertExtension = self.alertExtension
         
         settings.strikethroughExtension = self.strikethroughExtension ? (self.strikethroughDoubleTildeOption ? .double : .single) : .disabled
         

--- a/Resources/default.css
+++ b/Resources/default.css
@@ -197,6 +197,45 @@ table, table *, pre {
   padding-left: 0;
 }
 
+/* GitHub Alerts (alert extension) */
+.markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 16px;
+  border-left: 0.25em solid var(--alert-border);
+}
+.markdown-alert > :first-child { margin-top: 0; }
+.markdown-alert > :last-child { margin-bottom: 0; }
+.markdown-alert .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  color: var(--alert-color);
+}
+.markdown-alert .markdown-alert-title::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  background-color: var(--alert-color);
+  -webkit-mask-image: var(--alert-icon);
+  mask-image: var(--alert-icon);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+.markdown-alert-note      { --alert-color: #0969da; --alert-border: #0969da; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E"); }
+.markdown-alert-tip       { --alert-color: #1a7f37; --alert-border: #1a7f37; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E"); }
+.markdown-alert-important { --alert-color: #8250df; --alert-border: #8250df; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E"); }
+.markdown-alert-warning   { --alert-color: #9a6700; --alert-border: #9a6700; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E"); }
+.markdown-alert-caution   { --alert-color: #cf222e; --alert-border: #cf222e; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E"); }
+
+@media (prefers-color-scheme: dark) {
+  .markdown-alert-note      { --alert-color: #4493f8; --alert-border: #4493f8; }
+  .markdown-alert-tip       { --alert-color: #3fb950; --alert-border: #3fb950; }
+  .markdown-alert-important { --alert-color: #ab7df8; --alert-border: #ab7df8; }
+  .markdown-alert-warning   { --alert-color: #d29922; --alert-border: #d29922; }
+  .markdown-alert-caution   { --alert-color: #f85149; --alert-border: #f85149; }
+}
+
 pre, code, kbd {
   font-size: 1rem;
   font-family: var(--code-font);

--- a/cmark-extra/extensions/alert.c
+++ b/cmark-extra/extensions/alert.c
@@ -1,0 +1,150 @@
+//
+//  alert.c
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+//  GitHub Alerts (a.k.a. admonitions): blockquotes whose first line is
+//  `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` are
+//  rendered as styled callout boxes, matching GitHub's behaviour.
+//
+
+#include "alert.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+
+#include "../../cmark-gfm/src/parser.h"
+#include "../../cmark-gfm/src/render.h"
+#include "../../cmark-gfm/src/html.h"
+
+static const char *alert_markers[5] = { "[!NOTE]", "[!TIP]", "[!IMPORTANT]", "[!WARNING]", "[!CAUTION]" };
+static const char *alert_class[5]   = { "note", "tip", "important", "warning", "caution" };
+static const char *alert_label[5]   = { "Note", "Tip", "Important", "Warning", "Caution" };
+
+// Return the alert type index (0..4) when `literal` is exactly an alert marker
+// (case-insensitive keyword, trailing spaces allowed), otherwise -1. GitHub
+// requires the marker to be alone on the blockquote's first line.
+static int alert_type_for(const char *literal) {
+    if (literal == NULL) {
+        return -1;
+    }
+    size_t len = strlen(literal);
+    while (len > 0 && (literal[len - 1] == ' ' || literal[len - 1] == '\t')) {
+        len--;
+    }
+    for (int i = 0; i < 5; i++) {
+        size_t marker_len = strlen(alert_markers[i]);
+        if (len == marker_len && strncasecmp(literal, alert_markers[i], marker_len) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// Remove the "[!TYPE]" marker text (and the line break that follows it) from
+// the first paragraph of the block quote; drop the paragraph if it ends empty.
+static void strip_marker(cmark_node *block_quote) {
+    cmark_node *paragraph = cmark_node_first_child(block_quote);
+    if (paragraph == NULL || cmark_node_get_type(paragraph) != CMARK_NODE_PARAGRAPH) {
+        return;
+    }
+    cmark_node *marker = cmark_node_first_child(paragraph);
+    if (marker == NULL || cmark_node_get_type(marker) != CMARK_NODE_TEXT) {
+        return;
+    }
+    cmark_node_unlink(marker);
+    cmark_node_free(marker);
+
+    cmark_node *next = cmark_node_first_child(paragraph);
+    if (next != NULL && (cmark_node_get_type(next) == CMARK_NODE_SOFTBREAK || cmark_node_get_type(next) == CMARK_NODE_LINEBREAK)) {
+        cmark_node_unlink(next);
+        cmark_node_free(next);
+    }
+
+    if (cmark_node_first_child(paragraph) == NULL) {
+        cmark_node_unlink(paragraph);
+        cmark_node_free(paragraph);
+    }
+}
+
+static cmark_node *postprocess(cmark_syntax_extension *ext, cmark_parser *parser, cmark_node *root) {
+    cmark_consolidate_text_nodes(root);
+
+    cmark_mem *mem = cmark_get_default_mem_allocator();
+    cmark_llist *matches = NULL;
+
+    cmark_iter *iter = cmark_iter_new(root);
+    cmark_event_type ev;
+    while ((ev = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+        if (ev != CMARK_EVENT_ENTER) {
+            continue;
+        }
+        cmark_node *node = cmark_iter_get_node(iter);
+        if (cmark_node_get_type(node) != CMARK_NODE_BLOCK_QUOTE) {
+            continue;
+        }
+        cmark_node *paragraph = cmark_node_first_child(node);
+        if (paragraph == NULL || cmark_node_get_type(paragraph) != CMARK_NODE_PARAGRAPH) {
+            continue;
+        }
+        cmark_node *text = cmark_node_first_child(paragraph);
+        if (text == NULL || cmark_node_get_type(text) != CMARK_NODE_TEXT) {
+            continue;
+        }
+        int type = alert_type_for(cmark_node_get_literal(text));
+        if (type < 0) {
+            continue;
+        }
+
+        // Tag the node now (does not mutate the tree); strip the marker later.
+        cmark_node_set_user_data(node, (void *)(intptr_t)(type + 1));
+        cmark_node_set_syntax_extension(node, ext);
+        matches = cmark_llist_append(mem, matches, node);
+    }
+    cmark_iter_free(iter);
+
+    // Strip markers after iteration to avoid mutating the tree while walking it.
+    for (cmark_llist *tmp = matches; tmp != NULL; tmp = tmp->next) {
+        strip_marker((cmark_node *)tmp->data);
+    }
+    cmark_llist_free(mem, matches);
+
+    return root;
+}
+
+static void html_render(cmark_syntax_extension *extension,
+                        struct cmark_html_renderer *renderer,
+                        cmark_node *node,
+                        cmark_event_type ev_type,
+                        int options) {
+    intptr_t stored = (intptr_t)cmark_node_get_user_data(node);
+    if (stored < 1 || stored > 5) {
+        return;
+    }
+    int idx = (int)(stored - 1);
+    cmark_strbuf *html = renderer->html;
+
+    if (ev_type == CMARK_EVENT_ENTER) {
+        cmark_html_render_cr(html);
+        cmark_strbuf_puts(html, "<div class=\"markdown-alert markdown-alert-");
+        cmark_strbuf_puts(html, alert_class[idx]);
+        cmark_strbuf_puts(html, "\">\n");
+        cmark_strbuf_puts(html, "<p class=\"markdown-alert-title\">");
+        cmark_strbuf_puts(html, alert_label[idx]);
+        cmark_strbuf_puts(html, "</p>\n");
+    } else {
+        cmark_strbuf_puts(html, "</div>\n");
+        cmark_html_render_cr(html);
+    }
+}
+
+cmark_syntax_extension *create_alert_extension(void) {
+    cmark_syntax_extension *ext = cmark_syntax_extension_new("alert");
+
+    cmark_syntax_extension_set_postprocess_func(ext, postprocess);
+    cmark_syntax_extension_set_html_render_func(ext, html_render);
+
+    return ext;
+}

--- a/cmark-extra/extensions/alert.h
+++ b/cmark-extra/extensions/alert.h
@@ -1,0 +1,15 @@
+//
+//  alert.h
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+
+#ifndef alert_h
+#define alert_h
+
+#include "cmark-gfm-core-extensions.h"
+
+cmark_syntax_extension *create_alert_extension(void);
+
+#endif /* alert_h */

--- a/cmark-extra/extensions/extra-extensions.c
+++ b/cmark-extra/extensions/extra-extensions.c
@@ -21,6 +21,7 @@
 #include "math_ext.h"
 #include "sub_ext.h"
 #include "sup_ext.h"
+#include "alert.h"
 
 static int extra_extensions_registration(cmark_plugin *plugin) {
     cmark_plugin_register_syntax_extension(plugin, create_mention_extension());
@@ -35,6 +36,7 @@ static int extra_extensions_registration(cmark_plugin *plugin) {
     cmark_plugin_register_syntax_extension(plugin, create_math_extension());
     cmark_plugin_register_syntax_extension(plugin, create_sup_extension());
     cmark_plugin_register_syntax_extension(plugin, create_sub_extension());
+    cmark_plugin_register_syntax_extension(plugin, create_alert_extension());
     return 1;
 }
 

--- a/examples/test-github-alerts.md
+++ b/examples/test-github-alerts.md
@@ -1,0 +1,46 @@
+# GitHub alerts
+
+With the `alert` extension a blockquote whose first line is one of `[!NOTE]`,
+`[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` is rendered as a colored
+callout, like on GitHub.
+
+## The five types
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+## The marker is case-insensitive
+
+> [!tip]
+> `[!tip]`, `[!Tip]` and `[!TIP]` all produce the same callout.
+
+## Rich content is preserved
+
+> [!IMPORTANT]
+> Alerts can span multiple paragraphs and contain inline markup such as
+> **bold**, _italic_ and `code`.
+>
+> - they can hold lists,
+> - [links](https://github.com),
+> - and other block content.
+
+## Ordinary blockquotes are left untouched
+
+A blockquote without a marker, or whose marker is not alone on the first line,
+renders as a normal blockquote:
+
+> Just a regular quote, not an alert.
+
+> [!NOTE] text on the same line as the marker is not an alert either.

--- a/examples/test1.md
+++ b/examples/test1.md
@@ -16,6 +16,7 @@ The previous block placed at the top of the document, starting with `---` and en
 - [Extensions](#extensions)
   - [Autolink extension](#autolink-extension)
   - [Emoji extension](#emoji-extension)
+  - [GitHub alerts extension](#github-alerts-extension)
   - [GitHub mentions extension](#github-mentions-extension)
   - [Heads extension](#heads-extension)
   - [Highlight extension](#highlight-extension)
@@ -44,6 +45,25 @@ Using the `emoji` extension you can replace the `:smile:` with :smile:.
 
 You can choose to use the standard emoji font or the GitHub images.
 Multibyte emoji are also supported, so `:it:` equivalent to the code `\u1f1ee\u1f1f9` must be rendered as the Italian flag :it:.
+
+## GitHub alerts extension
+
+With the `alert` extension a blockquote whose first line is one of `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` is rendered as a colored callout, matching GitHub.
+
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
 
 ## GitHub mentions extension
 

--- a/qlmarkdown_cli/qlmarkdown_cli.swift
+++ b/qlmarkdown_cli/qlmarkdown_cli.swift
@@ -183,6 +183,9 @@ struct ExtensionsOptions: ParsableArguments {
     @Option(help: ArgumentHelp("Format superscript characters inside `^` markers.", valueName: "on|off"))
     var sup: BoolArgumentEnum? = nil
     
+    @Option(help: ArgumentHelp("Render GitHub alerts (blockquotes starting with [!NOTE], [!TIP], …).", valueName: "on|off"))
+    var alert: BoolArgumentEnum? = nil
+
     @Option(help: "Render the yaml header.")
     var yaml: YamlArgumentEnum? = nil
 }
@@ -368,6 +371,9 @@ struct QLMarkdownCLI: ParsableCommand {
         }
         if let o = extensions.sup {
             settings.supExtension = o == .on
+        }
+        if let o = extensions.alert {
+            settings.alertExtension = o == .on
         }
         if let o = extensions.yaml {
             switch o {


### PR DESCRIPTION
Adds GitHub-style alerts / admonitions (closes #143, also covers #170). cmark-gfm renders these as plain blockquotes, so this is a post-process `cmark-extra` extension (`alert.c`), modeled on the existing `heads` extension — the cmark engine itself is untouched.

A blockquote whose first line is `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]` or `[!CAUTION]` is rewritten into GitHub's alert markup:

```md
> [!NOTE]
> Useful information that users should know, even when skimming.

> [!WARNING]
> Urgent info that needs immediate user attention.
```

→

```html
<div class="markdown-alert markdown-alert-note">
<p class="markdown-alert-title">Note</p>
<p>Useful information that users should know, even when skimming.</p>
</div>
<div class="markdown-alert markdown-alert-warning">
<p class="markdown-alert-title">Warning</p>
<p>Urgent info that needs immediate user attention.</p>
</div>
```

### Behaviour

- **Off by default.** The marker is case-insensitive and must be alone on the blockquote's first line (matching GitHub), so ordinary blockquotes — and blockquotes that merely start with a colon or contain `[!…]` mid-line — are left untouched.
- The marker line is stripped; the rest of the blockquote (multiple paragraphs, lists, inline markup) is preserved.
- The five alert styles (GitHub's colors + Octicon icons, light & dark) are added to the bundled `default.css`.

### How it's exposed

- **Preferences UI** — a new **"GitHub alert" checkbox** in the Extensions grid, wired with bindings exactly like the other extension toggles (value → `alertExtension`, enabled → `renderAsCode` via `NSNegateBoolean`).
- **CLI** — a `--alert on|off` option.
- **Settings** — an `alertExtension` flag (`Codable` + app-group defaults), defaulting to off.

### Examples

- Adds `examples/test-github-alerts.md` (the five types, case-insensitivity, rich multi-block content, and the "ordinary blockquote untouched" case).
- Enriches `examples/test1.md` — the file shown in the **Settings live preview** — with a "GitHub alerts extension" section and its TOC entry, so the effect is visible the moment the checkbox is toggled.

### Changed files

- `cmark-extra/extensions/alert.{c,h}`, `extra-extensions.c` — the extension and its registration
- `QLMarkdown/Settings.swift`, `Settings+render.swift`, `Settings+ext.swift` — the flag and render wiring
- `qlmarkdown_cli/qlmarkdown_cli.swift` — the CLI option
- `QLMarkdown/ViewController.swift`, `Base.lproj/Main.storyboard` — the Preferences checkbox
- `Resources/default.css` — the alert styles (colors + Octicons, light & dark)
- `examples/test-github-alerts.md`, `examples/test1.md` — examples

| Light | Dark |
|---|---|
| ![light](https://s.soreavis.com/SCR-20260628-1s7p.png) | ![dark](https://s.soreavis.com/SCR-20260628-1tfp.png) |

The labels use GitHub's English text + icon to mirror GitHub's own rendering. As raised in the thread, switching to **icon-only** (no text) is a one-line CSS change if you'd rather avoid English-only labels — happy to go either way.

Closes #143. Also addresses #170.
