### PR TITLE
Fix release build dependency issues

### DIFF
--- a/QLMarkdown.xcodeproj/project.pbxproj
+++ b/QLMarkdown.xcodeproj/project.pbxproj
@@ -2169,6 +2169,7 @@
 				);
 				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)/QLMarkdown.app/Contents/Resources";
 				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path",
 					"@loader_path/../Frameworks",
 					"@executable_path/../Frameworks",
 					"$(inherited)",
@@ -2226,6 +2227,7 @@
 				);
 				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)/QLMarkdown.app/Contents/Resources";
 				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path",
 					"@loader_path/../Frameworks",
 					"@executable_path/../Frameworks",
 					"$(inherited)",

--- a/README.md
+++ b/README.md
@@ -404,10 +404,10 @@ The app uses the following libraries:
 - [MathJax](https://www.mathjax.org/) for mathematical expressions rendering.
 - [Mermaid](https://mermaid.js.org/) for diagrams rendering.
 
-`libpcre` require the `autoconf` utility to be build. You can install it with [`homebrew`](https://brew.sh/):
+`libpcre2` requires the `autoconf`, `automake`, and `libtool` utilities to be built. You can install them with [`homebrew`](https://brew.sh/):
 
 ```sh
-brew install autoconf
+brew install autoconf automake libtool
 ``` 
 
 The compilation of `cmark-gfm` require `cmake` (`brew install cmake`). 


### PR DESCRIPTION
## Summary
- update the cmark-gfm submodule to upstream 0.29.0.gfm.13 because the previous pinned commit cannot be fetched from github/cmark-gfm
- add @executable_path to qlmarkdown_cli runpaths so the Release CLI can resolve libwrapper_highlight.dylib from BUILT_PRODUCTS_DIR
- document the full pcre2 autotools prerequisites: autoconf, automake, and libtool

## Verification
- xcodebuild -project QLMarkdown.xcodeproj -scheme QLMarkdown -configuration Release -derivedDataPath /private/tmp/QLMarkdownDerivedData -clonedSourcePackagesDirPath /private/tmp/QLMarkdownSourcePackages -jobs 1 -quiet CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project QLMarkdown.xcodeproj -scheme qlmarkdown_cli -configuration Release -derivedDataPath /private/tmp/QLMarkdownDerivedData -clonedSourcePackagesDirPath /private/tmp/QLMarkdownSourcePackages -jobs 1 -quiet CODE_SIGNING_ALLOWED=NO build
- /private/tmp/QLMarkdownDerivedData/Build/Products/Release/QLMarkdown.app/Contents/MacOS/QLMarkdown -cv_note 0 stayed running without immediate crash
- /private/tmp/QLMarkdownDerivedData/Build/Products/Release/qlmarkdown_cli --help
- /private/tmp/QLMarkdownDerivedData/Build/Products/Release/qlmarkdown_cli --app /private/tmp/QLMarkdownDerivedData/Build/Products/Release/QLMarkdown.app -o /private/tmp/qlmarkdown-test1-app.html examples/test1.md

Note: a fully signed Release build still requires maintainer signing certificates/provisioning profiles; local validation used CODE_SIGNING_ALLOWED=NO.