### PR TITLE
Fix stale custom CSS preview when switching themes

### DIFF
--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -499,6 +499,7 @@ class Settings: Codable {
     var customCSS: URL? {
         didSet {
             customCSSFetched = false
+            customCSSCode = nil
         }
     }
     var customCSSFetched: Bool = false
@@ -744,6 +745,7 @@ class Settings: Codable {
         self.baseFontSize = s.baseFontSize
         self.customCSS = s.customCSS
         self.customCSSCode = s.customCSSCode
+        self.customCSSFetched = s.customCSSFetched
         self.customCSSOverride = s.customCSSOverride
         
         self.about = s.about

--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -378,10 +378,14 @@ class ViewController: NSViewController {
         }
         
         var index = 1
-        while stylesPopup.item(at: index)?.tag ?? -1 >= 0 {
+        if stylesPopup.item(at: index)?.isSeparatorItem ?? false {
             index += 1
         }
-        index -= 1
+        while index < stylesPopup.numberOfItems,
+              !(stylesPopup.item(at: index)?.isSeparatorItem ?? false),
+              stylesPopup.item(at: index)?.tag ?? -1 >= 0 {
+            index += 1
+        }
         stylesPopup.insertItem(withTitle: name, at: index)
         if standalone {
             stylesPopup.menu?.item(at: index)?.tag = 1


### PR DESCRIPTION
## Summary
This fixes the custom CSS theme refresh/persistence issue reported in #206.

The preferences preview could keep using stale custom CSS after the selected theme changed because the selected stylesheet URL, cached stylesheet contents, and fetched-state flag could get out of sync. This PR keeps those pieces of state aligned and makes custom stylesheet menu insertion less fragile.

## Changes
- Clear `customCSSCode` whenever `customCSS` changes, so an old stylesheet body cannot be reused after selecting another theme.
- Copy `customCSSFetched` in `Settings.update(from:)` together with `customCSSCode`, so settings loaded from shared defaults preserve the same cache-validity state as the source settings object.
- Update custom stylesheet popup insertion to skip separators explicitly and scan existing custom stylesheet items before inserting a new one. This avoids relying on separator tag defaults and the previous `index -= 1` adjustment.

## Reproduction / version notes
- The issue was reported against QLMarkdown 1.0.24 (50).
- I reproduced the stale custom CSS mismatch on a pre-fix build from current `main`, which is versioned as 1.5.2 (53).
- In the pre-fix build, switching between two custom CSS themes could leave the persisted `customCSS` value on the previous stylesheet while the preferences UI/preview had moved to the newly selected theme.
- After this patch, the same custom-theme switching flow keeps the dropdown selection, rendered preview, and persisted `customCSS` value aligned.

## Behavior verified
- Switching from one custom CSS theme to another updates:
  - the selected dropdown item
  - the rendered preferences preview
  - the persisted `customCSS` value when Autosave is enabled
- Switching back to `GitHub (Default)` clears the persisted custom CSS selection and updates the preview.
- With Autosave disabled, selecting another custom CSS theme updates the preview but does not persist the new selection.

## Testing
- `git diff --check`
- `xcodebuild -project QLMarkdown.xcodeproj -scheme QLMarkdown -configuration Debug -derivedDataPath /tmp/QLMarkdownDerived CODE_SIGNING_ALLOWED=NO build`
- Manual preferences-window verification with multiple visually distinct custom CSS themes.

Fixes #206.
