### PR TITLE
Fix heading anchor ids to match GitHub (underscores, consecutive whitespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ It is possibile to set a custom base font size. This size (in points) will be us
 |Autolink|Automatically translate URL to link and parse email addresses.|
 |Emoji|Enable the [Emoji extension](#emoji).|
 |GitHub mentions|Translate mentions to link to the GitHub account.|
-|<a name="heads-anchors"></a>Heads anchors|Create anchors for the heads to use as cross internal reference. Each anchor is named with the lowercased caption, stripped of any punctuation marks (except the dash) and spaces replaced with dash (`-`). UTF8 character encoding is supported.|
+|<a name="heads-anchors"></a>Heads anchors|Create anchors for the heads to use as cross internal reference. Each anchor is named with the lowercased caption, stripped of any punctuation marks (except the dash and the underscore) and each space replaced with a dash (`-`). UTF8 character encoding is supported.|
 |Highlight|Highlight the text contained between the markers `==`.|
 |Inline local images|Enable the [Inline local images extension](#inline-local-images).|
 |Math|Enable the [formatting of math expressions](#mathematical-expressions).|

--- a/cmark-extra/extensions/heads_utils.cpp
+++ b/cmark-extra/extensions/heads_utils.cpp
@@ -108,8 +108,8 @@ static char *process_title_re2(const char *title) {
     
     string text = title;
     
-    // Removes characters that are not alphanumeric or spaces or dashes.
-    RE2 re("[^\\p{L}\\p{N} -]+");
+    // Removes characters that are not alphanumeric or underscores or spaces or dashes.
+    RE2 re("[^\\p{L}\\p{N}_ -]+");
     if (!re.ok()) {
         return nullptr;
     }
@@ -154,12 +154,14 @@ class PCRE2_re
     private:
         PCRE2_re() {
             invalidChars_re
-                .setPattern(L"[^\\p{L}\\p{N} -]+") // Not letters, not numbers, not spaces, not dash.
+                .setPattern(L"[^\\p{L}\\p{N}_ -]+") // Not letters, not numbers, not underscores, not spaces, not dash.
                 .addModifier("inuS") // i: case insensitive, n: unicode support, u: utf support, S: jit compiler
                 .compile();
             
             spaces_re
-                .setPattern(L"\\s+")
+                // No quantifier: each whitespace maps to one dash, so a run of
+                // whitespace yields a run of dashes (GitHub behaviour).
+                .setPattern(L"\\s")
                 .addModifier("inuS") // i: case insensitive, n: unicode support, u: utf support, S: jit compiler
                 .compile();
         }                    // Constructor? (the {} brackets) are needed here.


### PR DESCRIPTION
# Fix heading anchor ids to match GitHub (underscores, consecutive whitespace)

## Summary

The heads extension produces heading ids that differ from GitHub's for two classes of
headings, so `[text](#anchor)` links written against GitHub do not jump in the Quick Look
preview.

`heads_utils.cpp` contains three slug implementations. `PCRE2_LIBRARY` is defined
unconditionally at the top of the file (`heads_utils.cpp:11`) and `RE2_LIBRARY` /
`REGEX_LIBRARY` are not defined anywhere in the project, so `process_title_pcre2` is
always the one that runs and the other two never compile. Notably, **the live
implementation is also the only one of the three that behaves this way** — which suggests
the divergence is unintended drift rather than a deliberate choice:

| implementation | underscores | whitespace |
|---|---|---|
| `process_title_std_regex` | `[^_[:alnum:] -]` → **kept** | `wregex(L" ")` → **1:1** |
| `process_title_re2` | not kept | `" "` → 1:1 |
| `process_title_pcre2` (**the live one**) | **not kept** | **`\s+` → collapsed** |

## The two divergences

**1. Underscore is stripped.** GitHub keeps `_` in slugs. `github-slugger`'s removal
class covers `[` through `^` (U+005B–U+005E) and then backtick onward, skipping U+005F.

**2. A run of whitespace collapses to a single dash.** `spaces_re` uses `\s+`.
GitHub replaces each space individually (`value.replace(/ /g, '-')`), so a run of
whitespace becomes a run of dashes. This matters more than it sounds: punctuation is
removed *before* the whitespace pass, so any heading with a punctuation mark between
two spaces — an em dash, for instance — leaves two adjacent spaces behind and GitHub
emits `--`.

## Test vectors

Measured by building this branch and its parent commit and running the bundled
`qlmarkdown_cli --heads-anchor on` against each. The GitHub column is the output of
`github-slugger` 2.0.0, not a hand-derived expectation.

| heading | GitHub | before | after |
|---|---|---|---|
| `Phase 1 — Korean entity (done)` | `phase-1--korean-entity-done` | `phase-1-korean-entity-done` ❌ | `phase-1--korean-entity-done` ✅ |
| `io_uring SQ/CQ queue sizing` | `io_uring-sqcq-queue-sizing` | `iouring-sqcq-queue-sizing` ❌ | `io_uring-sqcq-queue-sizing` ✅ |
| `AF_XDP offload` | `af_xdp-offload` | `afxdp-offload` ❌ | `af_xdp-offload` ✅ |
| `Multiple   spaces here` | `multiple---spaces-here` | `multiple-spaces-here` ❌ | `multiple---spaces-here` ✅ |
| `Overview` | `overview` | `overview` ✅ | `overview` ✅ |
| `Quick Start` | `quick-start` | `quick-start` ✅ | `quick-start` ✅ |

Cases I checked specifically for regressions from dropping the `+` quantifier, all
matching `github-slugger` both before and after:

| heading | GitHub | after |
|---|---|---|
| setext heading (`===` / `---` underlined) | `setext-level-one` | `setext-level-one` ✅ |
| `ATX with trailing spaces` (trailing spaces) | `atx-with-trailing-spaces` | `atx-with-trailing-spaces` ✅ |
| `Tab\tseparated` | `tabseparated` | `tabseparated` ✅ |
| `A B nbsp` (non-breaking space) | `ab-nbsp` | `ab-nbsp` ✅ |
| `C D emspace` (em space) | `cd-emspace` | `cd-emspace` ✅ |

Non-ASCII whitespace cannot reach `spaces_re`: `invalidChars_re` keeps only letters,
numbers, `_`, ASCII space and `-`, so anything else is already gone by then. That is why
dropping the quantifier is a 1:1 match for GitHub rather than an over-correction.

## Change

- `process_title_pcre2`: add `_` to the kept set; drop the `+` quantifier from `spaces_re`
- `process_title_re2`: add `_` to the kept set, so all three implementations agree
  (cosmetic — as noted above this one is not compiled)
- `process_title_std_regex` already matched GitHub and is untouched
- `README.md`: the “Heads anchors” row said punctuation is stripped “except the dash”,
  which no longer describes the behaviour once `_` is kept

Measured on a documentation corpus of 48 files / 1,498 anchor links written against
GitHub's algorithm: **427 links failed to resolve before, 19 after.**

## Known remaining difference (not addressed here)

All 19 residual failures are duplicate headings. GitHub appends `-1`, `-2` to repeated
slugs; `heads.c` has no duplicate tracking and emits the same `id` more than once. Adding
it needs per-render state that the extension does not currently carry, so it is left out
to keep this diff reviewable. Happy to open a separate issue or PR for it if you would
like.

## Verification

Built on macOS 26.6 / Xcode 26.6 (Apple silicon). The `Markdown QL Extension` target
builds clean in Release with no new warnings from the touched file, and the anchor output
was verified through `qlmarkdown_cli`, which renders via the same `Settings.render()` path
and the same `heads` extension the Quick Look extension uses.

I could not exercise the Quick Look UI itself — the project's bundle ids and team are
yours, so I have no provisioning profile to sign and register the appex locally. The
before/after comparison above is from the compiled extension code rather than from
clicking links in a preview window.
