### PR TITLE
Fix: diff code blocks render additions and deletions in the same color

### DIFF
--- a/Resources/default.css
+++ b/Resources/default.css
@@ -46,6 +46,10 @@
   --hl_Keyword-4: #6f42c1 ; /* ??? */
   --hl_Keyword-5: #d73a49 ; /* ??? */
   --hl_Keyword-6: #d73a49 ; /* ??? */
+
+  /* Diff-specific colors */
+  --hl_Diff_Deletion: #cf222e ;
+  --hl_Diff_Addition: #1a7f37 ;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -97,6 +101,10 @@
   --hl_Keyword-4: #eea8ff ; /* ??? */
   --hl_Keyword-5: #FF7B72 ; /* ??? */
   --hl_Keyword-6: #FF7B72 ; /* ??? */
+
+  /* Diff-specific colors */
+  --hl_Diff_Deletion: #ff7b72 ;
+  --hl_Diff_Addition: #3fb950 ;
   }
 }
 
@@ -118,6 +126,9 @@ pre.hl	{ background-color: var(--hl_Background);}
 .hl.kwd { color: var(--hl_Keyword-4); font-weight: normal;}
 .hl.kwe { color: var(--hl_Keyword-5); font-weight: normal;}
 .hl.kwf { color: var(--hl_Keyword-6); font-weight: normal;}
+
+code.language-diff .hl.kwa { color: var(--hl_Diff_Deletion); }
+code.language-diff .hl.kwb { color: var(--hl_Diff_Addition); }
 
 
 pre {


### PR DESCRIPTION
Fixes ```diff code blocks rendering additions and deletions in the same color. The `diff` language definition reuses the generic `Keyword-1`/`Keyword-2` token classes for deletion/addition lines, and `default.css` happens to assign both the same color (in both the light and dark palettes) — so every diff block renders entirely in red regardless of the fenced code block content. This is a `default.css`-only fix; no changes to `cmark-extra` or the `highlight` wrapper.

```diff
- removed line
+ added line
  unchanged line
```

Before this fix, the `-` and `+` lines above were indistinguishable (both red). After, deletions render in red and additions in green, matching the conventional diff / GitHub color scheme.

### Root cause

`Resources/highlight/langDefs/diff.lang` maps:
- lines starting with `-`/`<` (deletions) to the generic **Keyword-1** class (`hl.kwa`)
- lines starting with `+`/`>` (additions) to the generic **Keyword-2** class (`hl.kwb`)

These are the same generic keyword slots every other language uses, and their color comes entirely from the CSS variables in `default.css` (highlight theme names aren't wired up at runtime — `cmark_syntax_extension_highlight_set_theme_name` is always called with an empty string). In `default.css`, both the light and dark palettes define `--hl_Keyword-1` and `--hl_Keyword-2` with the **same value**, so `.hl.kwa` and `.hl.kwb` resolve to the same color and diffs render entirely in red.

There's a dedicated `Resources/highlight/themes/diff.theme` with a proper red/green palette, but it isn't connected to the rendering pipeline, and even if it were, a highlight "theme" applies to the whole render call rather than to a single fenced block — switching to it would recolor every other language in the document too.

### Fix

The HTML renderer (`cmark-extra/extensions/syntaxhighlight.c`) already emits a `language-<lang>` class on the `<code>` element:

```html
<code class="language-diff">
  <span class="hl kwa">-removed line</span>
  <span class="hl kwb">+added line</span>
</code>
```

This PR adds two new CSS variables, `--hl_Diff_Deletion` and `--hl_Diff_Addition` (light and dark), and scopes a pair of override rules to `code.language-diff`, so diff blocks get a proper red/green pair without touching `--hl_Keyword-1`/`--hl_Keyword-2`, which are shared by every other language and must keep their current values:

```css
code.language-diff .hl.kwa { color: var(--hl_Diff_Deletion); }
code.language-diff .hl.kwb { color: var(--hl_Diff_Addition); }
```

### Behaviour

- No preference, CLI flag, or settings change — the fix lives entirely in the bundled `default.css`, so it applies automatically wherever that stylesheet is used (Quick Look preview, the Settings live preview, and `qlmarkdown_cli`).
- Scoped to `code.language-diff` only, so no other language's colors (including its own reuse of `kwa`/`kwb`) are affected.
- Users with a custom CSS theme are unaffected unless they add the same variables/rules to their own stylesheet.

### Changed files

- `Resources/default.css` — new `--hl_Diff_Deletion` / `--hl_Diff_Addition` variables (light + dark) and the `code.language-diff` override rules

| Light | Dark |
|---|---|
| <img width="530" height="273" alt="image" src="https://github.com/user-attachments/assets/f40e480a-6d9e-4766-8dd9-5b08b7d04b7a" /> | <img width="515" height="253" alt="image" src="https://github.com/user-attachments/assets/565725cd-f939-40fc-8f51-cfbde97baecf" /> |
