### PR TITLE
Improve default/auto window size

### DIFF
--- a/QLExtension/PreviewViewController.swift
+++ b/QLExtension/PreviewViewController.swift
@@ -33,6 +33,19 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
     var launcherService: ExternalLauncherProtocol?
 
+    /// Size suggested to Quick Look. Reduced to fit the screen.
+    static var previewContentSize: CGSize {
+        let size = Settings.shared.qlWindowSize
+        guard let screen = NSScreen.main else {
+            return size
+        }
+        let available = screen.visibleFrame.size
+        return CGSize(
+            width: min(size.width, available.width * 0.9),
+            height: min(size.height, available.height * 0.9)
+        )
+    }
+
     override func viewDidDisappear() {
         // This code will not be called on macOS 12 Monterey with QLIsDataBasedPreview set.
 
@@ -59,7 +72,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
         let settings = Settings.shared
 
-        self.preferredContentSize = settings.qlWindowSize
+        self.preferredContentSize = Self.previewContentSize
 
         let previewRect: CGRect
         if #available(macOS 11, *) {
@@ -127,7 +140,7 @@ class PreviewViewController: NSViewController, QLPreviewingController {
 
         let html = try renderMD(url: request.fileURL)
 
-        let reply = QLPreviewReply(dataOfContentType: .html, contentSize: Settings.shared.qlWindowSize) { (replyToUpdate: QLPreviewReply) in
+        let reply = QLPreviewReply(dataOfContentType: .html, contentSize: Self.previewContentSize) { (replyToUpdate: QLPreviewReply) in
             replyToUpdate.stringEncoding = .utf8
             return html.data(using: .utf8)!
         }

--- a/QLMarkdown/Base.lproj/Main.storyboard
+++ b/QLMarkdown/Base.lproj/Main.storyboard
@@ -1795,11 +1795,7 @@
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                             <connections>
-                                                                <binding destination="XfG-lQ-9wD" name="hidden" keyPath="self.qlWindowSizeCustomized" id="D4r-xY-FIo">
-                                                                    <dictionary key="options">
-                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                                    </dictionary>
-                                                                </binding>
+                                                                <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.qlWindowSizeCustomized" id="Qa1-Wb-2cE"/>
                                                             </connections>
                                                         </textField>
                                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tlu-P4-LJS">
@@ -1819,11 +1815,6 @@
                                                             </textFieldCell>
                                                             <connections>
                                                                 <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.qlWindowSizeCustomized" id="ICt-7A-oNJ"/>
-                                                                <binding destination="XfG-lQ-9wD" name="hidden" keyPath="self.qlWindowSizeCustomized" previousBinding="ICt-7A-oNJ" id="zrz-6n-3wA">
-                                                                    <dictionary key="options">
-                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                                    </dictionary>
-                                                                </binding>
                                                                 <binding destination="XfG-lQ-9wD" name="value" keyPath="self.qlWindowWidth" id="cIl-gL-5JY"/>
                                                             </connections>
                                                         </textField>
@@ -1835,11 +1826,7 @@
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                             <connections>
-                                                                <binding destination="XfG-lQ-9wD" name="hidden" keyPath="self.qlWindowSizeCustomized" id="5uV-pg-0d6">
-                                                                    <dictionary key="options">
-                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                                    </dictionary>
-                                                                </binding>
+                                                                <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.qlWindowSizeCustomized" id="Rd3-Xf-4gH"/>
                                                             </connections>
                                                         </textField>
                                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r8q-Bk-FWd">
@@ -1855,11 +1842,6 @@
                                                             <connections>
                                                                 <binding destination="XfG-lQ-9wD" name="value" keyPath="self.qlWindowHeight" id="pHT-l1-scy"/>
                                                                 <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.qlWindowSizeCustomized" id="T3i-gk-t1c"/>
-                                                                <binding destination="XfG-lQ-9wD" name="hidden" keyPath="self.qlWindowSizeCustomized" previousBinding="T3i-gk-t1c" id="m8f-qa-qb5">
-                                                                    <dictionary key="options">
-                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                                    </dictionary>
-                                                                </binding>
                                                                 <outlet property="formatter" destination="ggW-M5-zt1" id="09n-c2-zli"/>
                                                             </connections>
                                                         </textField>
@@ -1871,11 +1853,7 @@
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                             <connections>
-                                                                <binding destination="XfG-lQ-9wD" name="hidden" keyPath="self.qlWindowSizeCustomized" id="jry-DB-rXw">
-                                                                    <dictionary key="options">
-                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                                                    </dictionary>
-                                                                </binding>
+                                                                <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.qlWindowSizeCustomized" id="Sj5-Yk-6lM"/>
                                                             </connections>
                                                         </textField>
                                                     </subviews>

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -827,11 +827,9 @@ table.debug td {
             
         // Custom Style applies in both modes; only the bundled GitHub default.css is
         // specific to Markdown (non-source) mode.
-        let css = (self.customCSSFetched ? self.customCSSCode : self.getCustomCSSCode()) ?? ""
-        css_doc_extended = formatCSS(css)
-        if !self.renderAsCode, css_doc_extended.isEmpty || !self.customCSSOverride {
-            css_doc += formatCSS(getBundleContents(forResource: "default", ofType: "css"))
-        }
+        let css = self.getAppliedCSS()
+        css_doc_extended = formatCSS(css.custom)
+        css_doc += formatCSS(css.bundled)
             
         var css_highlight: String = ""
         if self.renderAsCode {

--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -513,12 +513,29 @@ class Settings: Codable {
     var qlWindowWidth: Int? = nil
     /// Quick Look window height.
     var qlWindowHeight: Int? = nil
+    /// Width used when the style does not declare a content column.
+    static let defaultQLWindowWidth: CGFloat = 960
+    /// Height suggested to Quick Look. The preview scrolls if the content is longer.
+    static let defaultQLWindowHeight: CGFloat = 1000
+    /// Width used in `Render as code` mode, where the source is not laid out in a column.
+    static let defaultQLWindowWidthAsCode: CGFloat = 1400
     /// Quick Look window size.
+    /// Without a suggestion macOS opens a window as big as the screen.
     var qlWindowSize: CGSize {
         if let w = qlWindowWidth, w > 0, let h = qlWindowHeight, h > 0 {
             return CGSize(width: CGFloat(w), height: CGFloat(h))
         } else {
-            return CGSize(width: 0, height: 0)
+            return self.autoQLWindowSize
+        }
+    }
+    /// Size used when no custom size is set. Fitted to the content column of the style in use.
+    var autoQLWindowSize: CGSize {
+        if let column = self.contentColumnWidth {
+            return CGSize(width: column + 58, height: Self.defaultQLWindowHeight) // gutters and scroller
+        } else if self.renderAsCode {
+            return CGSize(width: Self.defaultQLWindowWidthAsCode, height: Self.defaultQLWindowHeight)
+        } else {
+            return CGSize(width: Self.defaultQLWindowWidth, height: Self.defaultQLWindowHeight)
         }
     }
     
@@ -959,6 +976,38 @@ class Settings: Codable {
             return nil
         }
         return try? String(contentsOf: url, encoding: .utf8)
+    }
+    
+    /**
+     * Get the style sheets applied to the rendered document, in cascade order.
+     * The bundled `default.css` is used only in Markdown mode. The custom style is emitted last.
+     */
+    func getAppliedCSS() -> (bundled: String?, custom: String) {
+        let custom = (self.customCSSFetched ? self.customCSSCode : self.getCustomCSSCode()) ?? ""
+        let useBundled = !self.renderAsCode && (custom.isEmpty || !self.customCSSOverride)
+        return (useBundled ? self.getBundleContents(forResource: "default", ofType: "css") : nil, custom)
+    }
+    
+    /// Width of the column used by the style to lay out the content. `nil` if no style declares it.
+    var contentColumnWidth: CGFloat? {
+        let css = self.getAppliedCSS()
+        // The custom style is emitted after the bundled one, so its declaration wins.
+        return parseContentColumnWidth(css.custom) ?? parseContentColumnWidth(css.bundled)
+    }
+    
+    /// Read the `--content-max-width` property. As in the cascade, the last declaration wins.
+    private func parseContentColumnWidth(_ css: String?) -> CGFloat? {
+        let pattern = #"--content-max-width\s*:\s*([0-9]+(?:\.[0-9]+)?)px"#
+        guard let css, let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return nil
+        }
+        guard let match = regex.matches(in: css, options: [], range: NSRange(css.startIndex..., in: css)).last,
+              let value = Range(match.range(at: 1), in: css).flatMap({ Double(css[$0]) }),
+              value > 0
+        else {
+            return nil
+        }
+        return CGFloat(value)
     }
     
     /**

--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -244,13 +244,13 @@ class ViewController: NSViewController {
             qlWindowSizePopupButton.selectItem(at: qlWindowSizeCustomized ? 1 : 0)
         }
     }
-    @objc dynamic var qlWindowWidth: Int = Settings.factorySettings.qlWindowWidth ?? 1000 {
+    @objc dynamic var qlWindowWidth: Int = Int(Settings.factorySettings.qlWindowSize.width) {
         didSet {
             guard oldValue != qlWindowWidth else { return }
             isDirty = true
         }
     }
-    @objc dynamic var qlWindowHeight: Int = Settings.factorySettings.qlWindowHeight ?? 800 {
+    @objc dynamic var qlWindowHeight: Int = Int(Settings.factorySettings.qlWindowSize.height) {
         didSet {
             guard oldValue != qlWindowHeight else { return }
             isDirty = true
@@ -1008,6 +1008,12 @@ class ViewController: NSViewController {
     
     @IBAction func handleQLSizeChanged(_ sender: NSPopUpButton) {
         self.qlWindowSizeCustomized = sender.indexOfSelectedItem == 1
+        if !self.qlWindowSizeCustomized {
+            // The fields are disabled but still visible. Show the size used by the automatic mode.
+            let size = Settings.shared.autoQLWindowSize
+            self.qlWindowWidth = Int(size.width)
+            self.qlWindowHeight = Int(size.height)
+        }
     }
     
     @IBAction func saveAction(_ sender: Any) {
@@ -1340,8 +1346,8 @@ document.addEventListener('scroll', function(e) {
         self.renderAsCode = settings.renderAsCode
         
         self.qlWindowSizeCustomized = settings.qlWindowWidth ?? 0 > 0 && settings.qlWindowHeight ?? 0 > 0
-        self.qlWindowWidth = settings.qlWindowWidth ?? 1000
-        self.qlWindowHeight = settings.qlWindowHeight ?? 800
+        self.qlWindowWidth = Int(settings.qlWindowSize.width)
+        self.qlWindowHeight = Int(settings.qlWindowSize.height)
         
         self.tableExtension = settings.tableExtension
         self.autoLinkExtension = settings.autoLinkExtension

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ User customized style sheet must have the settings for both light and dark appea
 
 The custom style is appended after the CSS used for the highlight the source code. In this way you can customize also the style of the syntax highlight. 
 
+If your style use a content column with a different width, declare it to size the Quick Look window accordingly:
+
+```css
+:root { --content-max-width: 1200px; }
+```
+
+Only `px` values are recognized.
+
 The theme popup menu has some extra commands available pressing the `alt` key.
 
 It is possibile to set a custom base font size. This size (in points) will be used for set the dimension of `1rem` in the css style sheet.
@@ -183,7 +191,7 @@ It is possibile to set a custom base font size. This size (in points) will be us
 
 Tou can also choose if open external link inside the Quick Look preview window or in the default browser.
 
-The `Quick Look window` option allow you to suggest a custom size for the content area of the Quick Look window. macOS does not always honor this setting.
+The `Quick Look window` option allow you to suggest a custom size for the content area of the Quick Look window. macOS does not always honor this setting. With `Auto` the size is derived from the [content column](#themes) of the theme in use (960 x 1000 points with the predefined theme, reduced to fit the screen). In `Render as code` mode the window is wider.
 > _Use with caution on macOS before version 12 Monterey_. 
 
 

--- a/Resources/default.css
+++ b/Resources/default.css
@@ -50,6 +50,10 @@
   /* Diff-specific colors */
   --hl_Diff_Deletion: #cf222e ;
   --hl_Diff_Addition: #1a7f37 ;
+
+  /* Read by QLMarkdown to size the Quick Look window.
+     Keep in sync with the min-width media query below, that can not use a variable. */
+  --content-max-width: 902px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -132,7 +136,7 @@ code.language-diff .hl.kwb { color: var(--hl_Diff_Addition); }
 
 
 pre {
-  max-width: 902px;
+  max-width: var(--content-max-width);
 }
 * {
   box-sizing: border-box;
@@ -169,7 +173,7 @@ body {
 
 article {
   margin: auto;
-  max-width: 902px;
+  max-width: var(--content-max-width);
   font-size: inherit;
   line-height: 1.5;
   word-wrap: break-word;


### PR DESCRIPTION
Improve out-of-the-box behavior: when installing and running QLMarkdown the 'auto' setting now gets a better suited window size. On larger screens (4k/5k res) the default quicklook window is very wide, with huge left - and right margins.