### PR TITLE
Fix Command-C for selected text in Quick Look

### DIFF
--- a/QLExtension/Info.plist
+++ b/QLExtension/Info.plist
@@ -27,7 +27,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>QLIsDataBasedPreview</key>
-			<true/>
+			<false/>
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>com.unknown.md</string>

--- a/QLExtension/PreviewViewController.swift
+++ b/QLExtension/PreviewViewController.swift
@@ -13,12 +13,12 @@ import external_launcher
 
 class MyWKWebView: WKWebView {
     override var canBecomeKeyView: Bool {
-        return false
+        return true
     }
 
-    override func becomeFirstResponder() -> Bool {
-        // Quick Look window do not allow first responder child.
-        return false
+    override func mouseDown(with event: NSEvent) {
+        self.window?.makeFirstResponder(self)
+        super.mouseDown(with: event)
     }
 }
 
@@ -37,6 +37,11 @@ class PreviewViewController: NSViewController, QLPreviewingController {
         // This code will not be called on macOS 12 Monterey with QLIsDataBasedPreview set.
 
         self.launcherService = nil
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        self.view.window?.makeFirstResponder(self.webView)
     }
 
     override func loadView() {
@@ -189,6 +194,7 @@ extension PreviewViewController: WKNavigationDelegate {
         // Wait to show the webview to prevent a resize glitch.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.webView?.isHidden = false
+            self.view.window?.makeFirstResponder(self.webView)
         }
     }
 


### PR DESCRIPTION
Fixes #177.

## What changed

- use the view-based Quick Look path so the extension-owned WKWebView participates in the responder chain
- allow the WKWebView to become the key view
- restore first responder after the view appears, after navigation finishes, and when the user clicks or drags to make a new selection

The current data-based HTML preview is rendered by the Quick Look host. On affected macOS Tahoe releases, the host intercepts Command-C before the rendered HTML can handle it. The existing view-based path gives the extension control of the WKWebView responder and makes repeated keyboard copies work.

## Validation

- macOS 26.6.2 (25G83), Apple Silicon
- Xcode 26.6 unsigned Debug build succeeded
- rendered a real Markdown file in Finder Quick Look
- copied rendered text with Command-C in three consecutive rounds, switching back to another app between rounds
- closed and reopened Quick Look, then copied again successfully
- verified the pasteboard contents changed from unique sentinels to the rendered Markdown text on every round

This is a draft because changing QLIsDataBasedPreview affects the preview architecture on macOS 12 and later, so maintainer feedback and broader OS coverage would be useful before merge.