### PR TITLE
Add admonition rendering extension

### DIFF
--- a/QLMarkdown.xcodeproj/project.pbxproj
+++ b/QLMarkdown.xcodeproj/project.pbxproj
@@ -283,6 +283,10 @@
 		83F8822E2598A5C6008C5071 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F8822C2598A5C0008C5071 /* WebKit.framework */; };
 		83F88259259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
 		83F8825A259906C7008C5071 /* heads.c in Sources */ = {isa = PBXBuildFile; fileRef = 83F88258259906C7008C5071 /* heads.c */; };
+		ADD0000000000000000000C1 /* admonition.c in Sources */ = {isa = PBXBuildFile; fileRef = ADD0000000000000000000BB /* admonition.c */; };
+		ADD0000000000000000000C2 /* admonition.c in Sources */ = {isa = PBXBuildFile; fileRef = ADD0000000000000000000BB /* admonition.c */; };
+		ADD0000000000000000000C3 /* admonition.c in Sources */ = {isa = PBXBuildFile; fileRef = ADD0000000000000000000BB /* admonition.c */; };
+		ADD0000000000000000000C4 /* admonition.c in Sources */ = {isa = PBXBuildFile; fileRef = ADD0000000000000000000BB /* admonition.c */; };
 		83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 		83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83F8825C25991BFC008C5071 /* heads_utils.cpp */; };
 /* End PBXBuildFile section */
@@ -700,6 +704,8 @@
 		83F8822C2598A5C0008C5071 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		83F88257259906C7008C5071 /* heads.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = heads.h; sourceTree = "<group>"; };
 		83F88258259906C7008C5071 /* heads.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = heads.c; sourceTree = "<group>"; };
+		ADD0000000000000000000AA /* admonition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = admonition.h; sourceTree = "<group>"; };
+		ADD0000000000000000000BB /* admonition.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = admonition.c; sourceTree = "<group>"; };
 		83F8825C25991BFC008C5071 /* heads_utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = heads_utils.cpp; sourceTree = "<group>"; };
 		83F8825D25991BFC008C5071 /* heads_utils.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = heads_utils.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -833,6 +839,8 @@
 				834CAB9A2593650800673002 /* emoji_utils.cpp */,
 				83F88257259906C7008C5071 /* heads.h */,
 				83F88258259906C7008C5071 /* heads.c */,
+				ADD0000000000000000000AA /* admonition.h */,
+				ADD0000000000000000000BB /* admonition.c */,
 				83F8825C25991BFC008C5071 /* heads_utils.cpp */,
 				83F8825D25991BFC008C5071 /* heads_utils.hpp */,
 				83CF71C72C5FCD780066A195 /* highlight.h */,
@@ -1476,6 +1484,7 @@
 				83F8825F25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				834A4F5629E8AD8E00692964 /* html.c in Sources */,
 				83F8825A259906C7008C5071 /* heads.c in Sources */,
+				ADD0000000000000000000C4 /* admonition.c in Sources */,
 				834A4F5929E8AD8E00692964 /* plugin.c in Sources */,
 				834A4F3E29E8AD8D00692964 /* references.c in Sources */,
 				83720A3925B8EA6600B49FEC /* decode.c in Sources */,
@@ -1555,6 +1564,7 @@
 				8320D5C52D1C3858005868BD /* tasklist.c in Sources */,
 				8320D5DE2D1C3AA7005868BD /* emoji.c in Sources */,
 				8320D5DF2D1C3AA7005868BD /* heads.c in Sources */,
+				ADD0000000000000000000C1 /* admonition.c in Sources */,
 				8320D5E02D1C3AA7005868BD /* inlineimage.c in Sources */,
 				8320D5E12D1C3AA7005868BD /* highlight.c in Sources */,
 				8320D5E22D1C3AA7005868BD /* sub_ext.c in Sources */,
@@ -1644,6 +1654,7 @@
 				834A4EF329E8AD8C00692964 /* strikethrough.c in Sources */,
 				83437974271D47DF00A5D6EA /* qlmarkdown_cli.swift in Sources */,
 				8343798D271D4A1900A5D6EA /* heads.c in Sources */,
+				ADD0000000000000000000C2 /* admonition.c in Sources */,
 				834A4F8429E92AE800692964 /* extra-extensions.c in Sources */,
 				834A4F1A29E8AD8D00692964 /* blocks.c in Sources */,
 				834A4F0129E8AD8C00692964 /* tagfilter.c in Sources */,
@@ -1663,6 +1674,7 @@
 				83F8825E25991BFC008C5071 /* heads_utils.cpp in Sources */,
 				83D22E642DCA659C0013EB9D /* Settings+render.swift in Sources */,
 				83F88259259906C7008C5071 /* heads.c in Sources */,
+				ADD0000000000000000000C3 /* admonition.c in Sources */,
 				835886B329E960050088DF7D /* math_ext.c in Sources */,
 				836B747D259E2D7B00A6A5F7 /* AboutViewController.swift in Sources */,
 				83327D202593FCEB00E76CF6 /* url.cpp in Sources */,

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -207,7 +207,16 @@ extension Settings {
                 os_log("Could not enable markdown `heads` extension!", log: OSLog.rendering, type: .error)
             }
         }
-        
+
+        if self.admonitionExtension {
+            if let ext = cmark_find_syntax_extension("admonition") {
+                cmark_parser_attach_syntax_extension(parser, ext)
+                os_log("Enabled markdown `admonition` extension.", log: OSLog.rendering, type: .debug)
+            } else {
+                os_log("Could not enable markdown `admonition` extension!", log: OSLog.rendering, type: .error)
+            }
+        }
+
         if self.highlightExtension {
             if let ext = cmark_find_syntax_extension("highlight") {
                 cmark_parser_attach_syntax_extension(parser, ext)

--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -224,6 +224,7 @@ class Settings: Codable {
         case autoLinkExtension
         case checkboxExtension
         case headsExtension
+        case admonitionExtension
         case hightlightExtension
         case inlineImageExtension
         case mathExtension
@@ -451,6 +452,7 @@ class Settings: Codable {
     var autoLinkExtension: Bool = true
     var checkboxExtension: Bool = false
     var headsExtension: Bool = true
+    var admonitionExtension: Bool = false
     var highlightExtension: Bool = false
     var inlineImageExtension: Bool = true
     var mathExtension: JSExtension = .link(url: nil)
@@ -530,6 +532,7 @@ class Settings: Codable {
         self.mentionExtension = try container.decode(Bool.self, forKey:.mentionExtension)
         self.checkboxExtension = try container.decode(Bool.self, forKey:.checkboxExtension)
         self.headsExtension = try container.decode(Bool.self, forKey:.headsExtension)
+        self.admonitionExtension = try container.decodeIfPresent(Bool.self, forKey: .admonitionExtension) ?? false
         self.highlightExtension = try container.decode(Bool.self, forKey: .hightlightExtension)
        
         self.syntaxHighlightExtension = try container.decode(Bool.self, forKey: .syntaxHighlightExtension)
@@ -606,6 +609,7 @@ class Settings: Codable {
         try container.encode(self.mentionExtension, forKey: .mentionExtension)
         try container.encode(self.checkboxExtension, forKey: .checkboxExtension)
         try container.encode(self.headsExtension, forKey: .headsExtension)
+        try container.encode(self.admonitionExtension, forKey: .admonitionExtension)
         try container.encode(self.highlightExtension, forKey: .hightlightExtension)
         
         try container.encode(self.syntaxHighlightExtension, forKey: .syntaxHighlightExtension)
@@ -696,7 +700,8 @@ class Settings: Codable {
         self.mentionExtension = s.mentionExtension
         self.checkboxExtension = s.checkboxExtension
         self.headsExtension = s.headsExtension
-        
+        self.admonitionExtension = s.admonitionExtension
+
         self.highlightExtension = s.highlightExtension
         
         self.syntaxHighlightExtension = s.syntaxHighlightExtension
@@ -772,6 +777,9 @@ class Settings: Codable {
         }
         if let ext = defaultsDomain[Self.CodingKeys.headsExtension.rawValue] as? Bool {
             headsExtension = ext
+        }
+        if let ext = defaultsDomain[Self.CodingKeys.admonitionExtension.rawValue] as? Bool {
+            admonitionExtension = ext
         }
         
         if let ext = defaultsDomain[Self.CodingKeys.hightlightExtension.rawValue] as? Bool {

--- a/Resources/default.css
+++ b/Resources/default.css
@@ -408,6 +408,45 @@ input[type="checkbox"] {
   margin-bottom: 16px;
 }
 
+/* Admonition callout boxes (admonition extension); shared styling with GitHub Alerts. */
+.markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 16px;
+  border-left: 0.25em solid var(--alert-border);
+}
+.markdown-alert > :first-child { margin-top: 0; }
+.markdown-alert > :last-child { margin-bottom: 0; }
+.markdown-alert .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  color: var(--alert-color);
+}
+.markdown-alert .markdown-alert-title::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  background-color: var(--alert-color);
+  -webkit-mask-image: var(--alert-icon);
+  mask-image: var(--alert-icon);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+.markdown-alert-note      { --alert-color: #0969da; --alert-border: #0969da; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E"); }
+.markdown-alert-tip       { --alert-color: #1a7f37; --alert-border: #1a7f37; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E"); }
+.markdown-alert-important { --alert-color: #8250df; --alert-border: #8250df; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E"); }
+.markdown-alert-warning   { --alert-color: #9a6700; --alert-border: #9a6700; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E"); }
+.markdown-alert-caution   { --alert-color: #cf222e; --alert-border: #cf222e; --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' width='16' height='16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E"); }
+
+@media (prefers-color-scheme: dark) {
+  .markdown-alert-note      { --alert-color: #4493f8; --alert-border: #4493f8; }
+  .markdown-alert-tip       { --alert-color: #3fb950; --alert-border: #3fb950; }
+  .markdown-alert-important { --alert-color: #ab7df8; --alert-border: #ab7df8; }
+  .markdown-alert-warning   { --alert-color: #d29922; --alert-border: #d29922; }
+  .markdown-alert-caution   { --alert-color: #f85149; --alert-border: #f85149; }
+}
+
 .markdown-body table {
   display: block;
   width: 100%;

--- a/cmark-extra/extensions/admonition.c
+++ b/cmark-extra/extensions/admonition.c
@@ -1,0 +1,221 @@
+//
+//  admonition.c
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+//  MkDocs-style admonitions: a `!!! type [title]` line followed by its content
+//  is rendered as a callout box, reusing the GitHub Alerts styling. cmark-gfm
+//  has no native support, so the compact one-block form — the `!!!` line and
+//  its softbreak-joined continuation in a single paragraph — is rewritten here
+//  in a post-process pass. Types map onto the five alert styles.
+//
+
+#include "admonition.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <ctype.h>
+
+#include "../../cmark-gfm/src/parser.h"
+#include "../../cmark-gfm/src/render.h"
+#include "../../cmark-gfm/src/html.h"
+
+static const char *alert_class[5] = { "note", "tip", "important", "warning", "caution" };
+
+// MkDocs admonition types mapped onto the five alert styles; anything else
+// falls back to "note" so every box stays themed.
+static const struct { const char *name; int idx; } type_aliases[] = {
+    { "note", 0 }, { "info", 0 }, { "question", 0 }, { "help", 0 },
+    { "tip", 1 }, { "hint", 1 }, { "success", 1 },
+    { "important", 2 }, { "example", 2 },
+    { "warning", 3 }, { "attention", 3 },
+    { "caution", 4 }, { "danger", 4 }, { "error", 4 }, { "bug", 4 }, { "failure", 4 },
+};
+
+static int resolve_type(const char *name, size_t len) {
+    for (size_t i = 0; i < sizeof(type_aliases) / sizeof(type_aliases[0]); i++) {
+        if (strlen(type_aliases[i].name) == len && strncasecmp(name, type_aliases[i].name, len) == 0) {
+            return type_aliases[i].idx;
+        }
+    }
+    return 0; // default: note
+}
+
+// Build the title: an explicit title (surrounding quotes stripped) when given,
+// otherwise the capitalized type word. Caller frees.
+static char *make_title(cmark_mem *mem, const char *rest, const char *type, size_t type_len) {
+    const char *start = rest;
+    const char *end = rest + strlen(rest);
+    while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+        end--;
+    }
+    // Strip a matching pair of surrounding quotes — straight, or the smart
+    // quotes that the CMARK_OPT_SMART option turns them into before we run.
+    if (end - start >= 2 && ((start[0] == '"' && end[-1] == '"') || (start[0] == '\'' && end[-1] == '\''))) {
+        start++;
+        end--;
+    } else if (end - start >= 6 && memcmp(start, "\xE2\x80\x9C", 3) == 0 && memcmp(end - 3, "\xE2\x80\x9D", 3) == 0) {
+        start += 3; // “ … ”
+        end -= 3;
+    } else if (end - start >= 6 && memcmp(start, "\xE2\x80\x98", 3) == 0 && memcmp(end - 3, "\xE2\x80\x99", 3) == 0) {
+        start += 3; // ‘ … ’
+        end -= 3;
+    }
+    if (end > start) {
+        size_t len = (size_t)(end - start);
+        char *title = (char *)mem->calloc(len + 1, 1);
+        memcpy(title, start, len);
+        return title;
+    }
+    char *title = (char *)mem->calloc(type_len + 1, 1);
+    memcpy(title, type, type_len);
+    title[0] = (char)toupper((unsigned char)title[0]);
+    for (size_t i = 1; i < type_len; i++) {
+        title[i] = (char)tolower((unsigned char)title[i]);
+    }
+    return title;
+}
+
+// Parse a `!!! type [title]` opener from the paragraph's leading text. Returns
+// the alert-style index (0..4) and allocates *title_out (caller frees), or -1
+// when the text is not an admonition opener.
+static int parse_opener(cmark_mem *mem, const char *literal, char **title_out) {
+    *title_out = NULL;
+    if (literal == NULL || strncmp(literal, "!!!", 3) != 0) {
+        return -1;
+    }
+    const char *p = literal + 3;
+    if (*p != ' ' && *p != '\t') {
+        return -1; // require whitespace after `!!!` (rejects `!!!!`, `!!!x`)
+    }
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    const char *type = p;
+    while (*p != '\0' && *p != ' ' && *p != '\t') {
+        p++;
+    }
+    size_t type_len = (size_t)(p - type);
+    if (type_len == 0) {
+        return -1;
+    }
+    int idx = resolve_type(type, type_len);
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    *title_out = make_title(mem, p, type, type_len);
+    return idx;
+}
+
+// An admonition needs content after the opener line: a soft break followed by
+// at least one more node. This also keeps the misleading empty box that the
+// blank-line MkDocs form (content parsed as a separate code block) would
+// otherwise produce, and avoids matching a lone `!!! word` paragraph.
+static int has_body(cmark_node *para) {
+    for (cmark_node *c = cmark_node_first_child(para); c != NULL; c = cmark_node_next(c)) {
+        cmark_node_type type = cmark_node_get_type(c);
+        if ((type == CMARK_NODE_SOFTBREAK || type == CMARK_NODE_LINEBREAK) && cmark_node_next(c) != NULL) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void convert(cmark_syntax_extension *ext, cmark_mem *mem, cmark_node *para, int idx, char *title) {
+    cmark_node *box = cmark_node_new_with_mem_and_ext(CMARK_NODE_CUSTOM_BLOCK, mem, ext);
+    cmark_node_set_user_data(box, (void *)(intptr_t)(idx + 1));
+    cmark_node_insert_before(para, box);
+
+    cmark_node *title_p = cmark_node_new_with_mem_and_ext(CMARK_NODE_PARAGRAPH, mem, ext);
+    cmark_node *title_text = cmark_node_new_with_mem(CMARK_NODE_TEXT, mem);
+    cmark_node_set_literal(title_text, title); // copies the string
+    mem->free(title);
+    cmark_node_append_child(title_p, title_text);
+    cmark_node_append_child(box, title_p);
+
+    // Drop the opener line: its inlines and the soft break that ends it.
+    cmark_node *child = cmark_node_first_child(para);
+    while (child != NULL) {
+        cmark_node_type type = cmark_node_get_type(child);
+        cmark_node *next = cmark_node_next(child);
+        cmark_node_unlink(child);
+        cmark_node_free(child);
+        if (type == CMARK_NODE_SOFTBREAK || type == CMARK_NODE_LINEBREAK) {
+            break;
+        }
+        child = next;
+    }
+
+    // Reuse `para` as the body so its content buffer stays alive to back the
+    // moved inlines — freeing it would dangle them. `has_body` guarantees the
+    // opener line left content behind.
+    cmark_node_unlink(para);
+    cmark_node_append_child(box, para);
+}
+
+static void process_children(cmark_syntax_extension *ext, cmark_mem *mem, cmark_node *parent) {
+    cmark_node *child = cmark_node_first_child(parent);
+    while (child != NULL) {
+        cmark_node *next = cmark_node_next(child); // capture before child may be unlinked
+        cmark_node_type type = cmark_node_get_type(child);
+        if (type == CMARK_NODE_PARAGRAPH) {
+            cmark_node *first = cmark_node_first_child(child);
+            if (first != NULL && cmark_node_get_type(first) == CMARK_NODE_TEXT) {
+                char *title = NULL;
+                int idx = parse_opener(mem, cmark_node_get_literal(first), &title);
+                if (idx >= 0 && has_body(child)) {
+                    convert(ext, mem, child, idx, title);
+                } else {
+                    mem->free(title); // NULL-safe; nothing allocated when idx < 0
+                }
+            }
+        } else if (type == CMARK_NODE_BLOCK_QUOTE) {
+            process_children(ext, mem, child);
+        }
+        child = next;
+    }
+}
+
+static cmark_node *postprocess(cmark_syntax_extension *ext, cmark_parser *parser, cmark_node *root) {
+    cmark_consolidate_text_nodes(root);
+    process_children(ext, parser->mem, root);
+    return root;
+}
+
+static void html_render(cmark_syntax_extension *extension,
+                        struct cmark_html_renderer *renderer,
+                        cmark_node *node,
+                        cmark_event_type ev_type,
+                        int options) {
+    cmark_strbuf *html = renderer->html;
+    int entering = ev_type == CMARK_EVENT_ENTER;
+
+    if (cmark_node_get_type(node) == CMARK_NODE_CUSTOM_BLOCK) {
+        intptr_t stored = (intptr_t)cmark_node_get_user_data(node);
+        if (stored < 1 || stored > 5) {
+            return;
+        }
+        if (entering) {
+            cmark_html_render_cr(html);
+            cmark_strbuf_puts(html, "<div class=\"markdown-alert markdown-alert-");
+            cmark_strbuf_puts(html, alert_class[stored - 1]);
+            cmark_strbuf_puts(html, "\">\n");
+        } else {
+            cmark_strbuf_puts(html, "</div>\n");
+            cmark_html_render_cr(html);
+        }
+    } else { // tagged paragraph = the admonition title
+        cmark_strbuf_puts(html, entering ? "<p class=\"markdown-alert-title\">" : "</p>\n");
+    }
+}
+
+cmark_syntax_extension *create_admonition_extension(void) {
+    cmark_syntax_extension *ext = cmark_syntax_extension_new("admonition");
+
+    cmark_syntax_extension_set_postprocess_func(ext, postprocess);
+    cmark_syntax_extension_set_html_render_func(ext, html_render);
+
+    return ext;
+}

--- a/cmark-extra/extensions/admonition.h
+++ b/cmark-extra/extensions/admonition.h
@@ -1,0 +1,15 @@
+//
+//  admonition.h
+//  QLMarkdown
+//
+//  Created by soreavis on 28/06/26.
+//
+
+#ifndef admonition_h
+#define admonition_h
+
+#include "cmark-gfm-core-extensions.h"
+
+cmark_syntax_extension *create_admonition_extension(void);
+
+#endif /* admonition_h */

--- a/cmark-extra/extensions/extra-extensions.c
+++ b/cmark-extra/extensions/extra-extensions.c
@@ -17,6 +17,7 @@
 #include "inlineimage.h"
 #include "emoji.h"
 #include "heads.h"
+#include "admonition.h"
 #include "highlight.h"
 #include "math_ext.h"
 #include "sub_ext.h"
@@ -31,6 +32,7 @@ static int extra_extensions_registration(cmark_plugin *plugin) {
 
     cmark_plugin_register_syntax_extension(plugin, create_emoji_extension());
     cmark_plugin_register_syntax_extension(plugin, create_heads_extension());
+    cmark_plugin_register_syntax_extension(plugin, create_admonition_extension());
     cmark_plugin_register_syntax_extension(plugin, create_highlight_extension());
     cmark_plugin_register_syntax_extension(plugin, create_math_extension());
     cmark_plugin_register_syntax_extension(plugin, create_sup_extension());

--- a/examples/test-admonition.md
+++ b/examples/test-admonition.md
@@ -1,0 +1,46 @@
+# Admonition Test
+
+This file tests admonition rendering (the `admonition` extension): a `!!! type [title]`
+line immediately followed by its indented content is rendered as a callout box.
+
+## Types
+
+!!! note
+    Useful information that users should know, even when skimming.
+
+!!! tip
+    A helpful suggestion for doing things better or more easily.
+
+!!! warning
+    Something the reader should be careful about.
+
+!!! caution
+    Negative consequences of an action.
+
+## Custom title
+
+!!! tip "Pro tip"
+    A quoted title replaces the default. The body supports *emphasis*, `code`, and [links](https://example.com).
+
+## Type synonyms
+
+!!! danger
+    Unknown and synonym types map onto the five styles — `danger` uses the caution style.
+
+## Inside a blockquote
+
+> !!! warning
+>     Admonitions also work inside blockquotes.
+
+## Not an admonition
+
+!!!note
+    Without a space after `!!!` this is not an admonition, so it stays a normal paragraph.
+
+## Regular Markdown Content
+
+Regular content renders normally alongside admonitions:
+
+- Item 1
+- Item 2
+- Item 3

--- a/qlmarkdown_cli/qlmarkdown_cli.swift
+++ b/qlmarkdown_cli/qlmarkdown_cli.swift
@@ -143,7 +143,10 @@ struct ExtensionsOptions: ParsableArguments {
     
     @Option(help: ArgumentHelp("Create anchors for the heads.", valueName: "on|off"))
     var headsAnchor: BoolArgumentEnum? = nil
-    
+
+    @Option(help: ArgumentHelp("Render `!!! type` admonitions as callout boxes.", valueName: "on|off"))
+    var admonition: BoolArgumentEnum? = nil
+
     @Option(help: ArgumentHelp("Highlight text marked with `==`.", valueName: "on|off"))
     var highlight: BoolArgumentEnum? = nil
     
@@ -298,6 +301,9 @@ struct QLMarkdownCLI: ParsableCommand {
         if let o = extensions.headsAnchor {
             settings.headsExtension = o == .on
         }
+        if let o = extensions.admonition {
+            settings.admonitionExtension = o == .on
+        }
         if let o = extensions.highlight {
             settings.highlightExtension = o == .on
         }
@@ -407,6 +413,7 @@ struct QLMarkdownCLI: ParsableCommand {
         }
         print("    --github-mentions: \(settings.mentionExtension ? "on" : "off")")
         print("    --heads-anchor: \(settings.headsExtension ? "on" : "off")")
+        print("    --admonition: \(settings.admonitionExtension ? "on" : "off")")
         print("    --highlight: \(settings.highlightExtension ? "on" : "off")")
         print("    --inline-images: \(settings.inlineImageExtension ? "on" : "off")")
         switch settings.mathExtension {


### PR DESCRIPTION
cmark-gfm has no native admonitions, so this adds MkDocs-style `!!! type [title]` callout boxes as a post-process cmark-extra extension (admonition.c), reusing the GitHub Alerts styling. Off by default behind a Settings flag and a --admonition CLI option. Types map onto the five alert styles and custom titles are supported. Adds examples/test-admonition.md. Re #68.