### PR TITLE
Add an optional table of contents sidebar to the preview

### DIFF
--- a/QLMarkdown/Base.lproj/Main.storyboard
+++ b/QLMarkdown/Base.lproj/Main.storyboard
@@ -948,7 +948,23 @@
                                                                 </connections>
                                                             </button>
                                                         </gridCell>
-                                                        <gridCell row="b1T-4W-Sf6" column="EM0-Js-ao5" id="Xpw-Ld-DuY"/>
+                                                        <gridCell row="b1T-4W-Sf6" column="EM0-Js-ao5" id="Xpw-Ld-DuY">
+                                                            <button key="contentView" toolTip="Show a clickable table-of-contents sidebar in the preview when the window is wide enough." horizontalHuggingPriority="246" verticalHuggingPriority="747" translatesAutoresizingMaskIntoConstraints="NO" id="Toc-Bt-n01">
+                                                                <rect key="frame" x="657" y="68" width="160" height="16"/>
+                                                                <buttonCell key="cell" type="check" title="Table of contents" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Toc-Cl-n02">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <binding destination="XfG-lQ-9wD" name="value" keyPath="self.tableOfContentsOption" id="Toc-Bv-n03"/>
+                                                                    <binding destination="XfG-lQ-9wD" name="enabled" keyPath="self.renderAsCode" id="Toc-Be-n04">
+                                                                        <dictionary key="options">
+                                                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                        </dictionary>
+                                                                    </binding>
+                                                                </connections>
+                                                            </button>
+                                                        </gridCell>
                                                         <gridCell row="mRf-rL-ZFR" column="Kw4-iz-WrK" id="ZwB-5j-pmJ">
                                                             <button key="contentView" toolTip="Handle URL and email addresses as link." horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MIB-mW-C6G">
                                                                 <rect key="frame" x="0.0" y="40" width="71" height="16"/>

--- a/QLMarkdown/Settings+ext.swift
+++ b/QLMarkdown/Settings+ext.swift
@@ -222,6 +222,7 @@ extension Settings {
         defaults.set(validateUTFOption, forKey: Self.CodingKeys.validateUTFOption.rawValue)
         defaults.set(smartQuotesOption, forKey: Self.CodingKeys.smartQuotesOption.rawValue)
         defaults.set(footnotesOption, forKey: Self.CodingKeys.footnotesOption.rawValue)
+        defaults.set(tableOfContentsOption, forKey: Self.CodingKeys.tableOfContentsOption.rawValue)
         
         if baseFontSize > 0 {
             defaults.set(baseFontSize, forKey: Self.CodingKeys.baseFontSize.rawValue)

--- a/QLMarkdown/Settings+render.swift
+++ b/QLMarkdown/Settings+render.swift
@@ -559,6 +559,7 @@ table.debug td {
         html_debug += "</td></tr>\n"
         
         html_debug += "<tr><td>heads extension</td><td>" + (self.headsExtension ?  "on" : "off") + "</td></tr>\n"
+        html_debug += "<tr><td>table of contents</td><td>" + (self.tableOfContentsOption ? "on" : "off") + "</td></tr>\n"
         
         html_debug += "<tr><td>highlight extension</td><td>"
         if self.highlightExtension {
@@ -891,6 +892,29 @@ securityLevel: 'strict'
         let wrapper_open = self.renderAsCode ? "<pre class='hl'>" : "<article class='markdown-body'>"
         let wrapper_close = self.renderAsCode ? "</pre>" : "</article>"
         let body_style = self.renderAsCode ? " class='hl'" : ""
+
+        // TOC sidebar prototype (issue #161): build a clickable navigation and rewrite each
+        // heading with a unique, clean anchor so duplicate / emoji headings each scroll correctly.
+        let toc = (self.renderAsCode || !self.tableOfContentsOption) ? nil : buildTOC(processedBody)
+        let tocCSS = toc == nil ? "" : Self.tocSidebarCSS
+
+        let article = "\(wrapper_open)\n\(toc?.body ?? processedBody)\n\(wrapper_close)"
+        let bodyContent: String
+        if let toc {
+            bodyContent = """
+<div class='toc-layout'>
+<nav class='toc-sidebar'>
+\(toc.toc)
+</nav>
+<main class='toc-main'>
+\(article)
+</main>
+</div>
+"""
+        } else {
+            bodyContent = article
+        }
+
         let html =
 """
 <!doctype html>
@@ -899,13 +923,11 @@ securityLevel: 'strict'
 <meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0'>
 <title>\(title)</title>
-\(style)
+\(style)\(tocCSS)
 \(s_header)
 </head>
 <body\(body_style)>
-\(wrapper_open)
-\(processedBody)
-\(wrapper_close)
+\(bodyContent)
 \(s_footer)
 \(Self.aboutComment)
 </body>
@@ -913,6 +935,117 @@ securityLevel: 'strict'
 """
         return html
     }
+
+    /// Build a clickable table-of-contents sidebar AND rewrite each heading with a fresh,
+    /// unique, clean anchor id, so duplicate headings and emoji-containing headings each scroll
+    /// to the right place (the `heads` extension neither de-dupes slugs nor cleans emoji titles).
+    /// Returns the rewritten body + the TOC markup, or nil when there are fewer than two headings.
+    private func buildTOC(_ body: String) -> (body: String, toc: String)? {
+        let pattern = "<h([1-6])([^>]*)>(.*?)</h[1-6]>"
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return nil
+        }
+        let ns = body as NSString
+        let matches = re.matches(in: body, range: NSRange(location: 0, length: ns.length))
+        guard matches.count >= 2 else {
+            return nil
+        }
+        let tagStripper = try? NSRegularExpression(pattern: "<[^>]+>", options: [])
+        let idStripper = try? NSRegularExpression(pattern: "\\s*id\\s*=\\s*\"[^\"]*\"", options: [.caseInsensitive])
+
+        var newBody = ""
+        var items = ""
+        var lastEnd = 0
+        var used: [String: Int] = [:]
+
+        for m in matches {
+            let full = m.range
+            let level = ns.substring(with: m.range(at: 1))
+            var attrs = ns.substring(with: m.range(at: 2))
+            let inner = ns.substring(with: m.range(at: 3))
+
+            // plain text of the heading (inline tags stripped) drives both the label and the slug
+            var text = inner
+            if let tagStripper {
+                let r = NSRange(location: 0, length: (text as NSString).length)
+                text = tagStripper.stringByReplacingMatches(in: text, range: r, withTemplate: "")
+            }
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            newBody += ns.substring(with: NSRange(location: lastEnd, length: full.location - lastEnd))
+            lastEnd = full.location + full.length
+
+            guard !text.isEmpty else {
+                // empty heading: keep it as-is, leave it out of the TOC
+                newBody += ns.substring(with: full)
+                continue
+            }
+
+            var slug = Self.slugify(text)
+            if slug.isEmpty {
+                slug = "section"
+            }
+            if let n = used[slug] {
+                used[slug] = n + 1
+                slug = "\(slug)-\(n + 1)"
+            } else {
+                used[slug] = 1
+            }
+
+            // replace any id the heads extension assigned with our unique one
+            if let idStripper {
+                let r = NSRange(location: 0, length: (attrs as NSString).length)
+                attrs = idStripper.stringByReplacingMatches(in: attrs, range: r, withTemplate: "")
+            }
+            newBody += "<h\(level)\(attrs) id=\"\(slug)\">\(inner)</h\(level)>"
+
+            let tooltip = text.replacingOccurrences(of: "\"", with: "&quot;")
+            items += "<li class='toc-l\(level)'><a href='#\(slug)' title=\"\(tooltip)\">\(text)</a></li>\n"
+        }
+        newBody += ns.substring(with: NSRange(location: lastEnd, length: ns.length - lastEnd))
+
+        guard !items.isEmpty else {
+            return nil
+        }
+        return (newBody, "<ul>\n\(items)</ul>")
+    }
+
+    /// Lowercase slug: keep unicode letters/digits, collapse every other run to a single dash.
+    private static func slugify(_ text: String) -> String {
+        var slug = ""
+        var pendingDash = false
+        for ch in text.lowercased() {
+            if ch.isLetter || ch.isNumber {
+                if pendingDash && !slug.isEmpty {
+                    slug.append("-")
+                }
+                slug.append(ch)
+                pendingDash = false
+            } else {
+                pendingDash = true
+            }
+        }
+        return slug
+    }
+
+    private static let tocSidebarCSS = """
+<style type='text/css'>
+html { scroll-behavior: smooth; }
+.toc-layout { display: flex; align-items: flex-start; }
+.toc-sidebar { position: sticky; top: 0; align-self: flex-start; max-height: 100vh; overflow-y: auto; flex: 0 0 28%; box-sizing: border-box; padding: 0.8em 0.5em; font-size: 0.8em; line-height: 1.35; }
+.toc-sidebar ul { list-style: none; margin: 0; padding: 0; }
+.toc-sidebar a { display: block; padding: 2px 4px; color: inherit; text-decoration: none; border-radius: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.toc-sidebar a:hover { background: rgba(128, 128, 128, 0.15); }
+.toc-main { flex: 1 1 auto; min-width: 0; padding-left: 1.5em; }
+.toc-main h1, .toc-main h2, .toc-main h3, .toc-main h4, .toc-main h5, .toc-main h6 { scroll-margin-top: 15px; }
+.toc-l1 { padding-left: 0; font-weight: 600; }
+.toc-l2 { padding-left: 0.9em; }
+.toc-l3 { padding-left: 1.8em; }
+.toc-l4 { padding-left: 2.7em; }
+.toc-l5, .toc-l6 { padding-left: 3.6em; }
+@media (max-width: 1300px) { .toc-sidebar { display: none; } .toc-main { padding-left: 0; } }
+</style>
+"""
     
     internal func parseYaml(node: Yams.Node) throws -> Any {
         switch node {

--- a/QLMarkdown/Settings.swift
+++ b/QLMarkdown/Settings.swift
@@ -247,6 +247,7 @@ class Settings: Codable {
         case unsafeHTMLOption
         case smartQuotesOption
         case validateUTFOption
+        case tableOfContentsOption
         case baseFontSize
         case customCSS
         case customCSSCode
@@ -475,6 +476,7 @@ class Settings: Codable {
     var unsafeHTMLOption: Bool = true
     var smartQuotesOption: Bool = true
     var validateUTFOption: Bool = false
+    var tableOfContentsOption: Bool = false
     
     var baseFontSize: CGFloat = 0
     var customCSS: URL? {
@@ -550,6 +552,7 @@ class Settings: Codable {
         self.validateUTFOption = try container.decode(Bool.self, forKey: .validateUTFOption)
         self.smartQuotesOption = try container.decode(Bool.self, forKey: .smartQuotesOption)
         self.footnotesOption = try container.decode(Bool.self, forKey: .footnotesOption)
+        self.tableOfContentsOption = try container.decodeIfPresent(Bool.self, forKey: .tableOfContentsOption) ?? false
         
         self.baseFontSize = try container.decode(CGFloat.self, forKey: .baseFontSize)
         self.customCSS = try container.decode(URL?.self, forKey: .customCSS)
@@ -626,6 +629,7 @@ class Settings: Codable {
         try container.encode(self.validateUTFOption, forKey: .validateUTFOption)
         try container.encode(self.smartQuotesOption, forKey: .smartQuotesOption)
         try container.encode(self.footnotesOption, forKey: .footnotesOption)
+        try container.encode(self.tableOfContentsOption, forKey: .tableOfContentsOption)
         
         try container.encode(self.baseFontSize, forKey: .baseFontSize)
         try container.encode(self.customCSS, forKey: .customCSS)
@@ -717,6 +721,7 @@ class Settings: Codable {
         self.validateUTFOption = s.validateUTFOption
         self.smartQuotesOption = s.smartQuotesOption
         self.footnotesOption = s.footnotesOption
+        self.tableOfContentsOption = s.tableOfContentsOption
         
         self.baseFontSize = s.baseFontSize
         self.customCSS = s.customCSS
@@ -824,6 +829,9 @@ class Settings: Codable {
         }
         if let opt = defaultsDomain[Self.CodingKeys.footnotesOption.rawValue] as? Bool {
             footnotesOption = opt
+        }
+        if let opt = defaultsDomain[Self.CodingKeys.tableOfContentsOption.rawValue] as? Bool {
+            tableOfContentsOption = opt
         }
         
         

--- a/QLMarkdown/ViewController.swift
+++ b/QLMarkdown/ViewController.swift
@@ -221,6 +221,12 @@ class ViewController: NSViewController {
             isDirty = true
         }
     }
+    @objc dynamic var tableOfContentsOption: Bool = Settings.factorySettings.tableOfContentsOption {
+        didSet {
+            guard oldValue != tableOfContentsOption else { return }
+            isDirty = true
+        }
+    }
     
     @objc dynamic var debugMode: Bool = Settings.factorySettings.debug {
         didSet {
@@ -1347,6 +1353,7 @@ document.addEventListener('scroll', function(e) {
         self.unsafeHTMLOption = settings.unsafeHTMLOption
         self.validateUTFOption = settings.validateUTFOption
         self.smartQuotesOption = settings.smartQuotesOption
+        self.tableOfContentsOption = settings.tableOfContentsOption
         self.footnotesOption = settings.footnotesOption
         
         self.customCSSFile = settings.customCSS
@@ -1411,6 +1418,7 @@ document.addEventListener('scroll', function(e) {
         settings.unsafeHTMLOption = self.unsafeHTMLOption
         settings.validateUTFOption = self.validateUTFOption
         settings.smartQuotesOption = self.smartQuotesOption
+        settings.tableOfContentsOption = self.tableOfContentsOption
         settings.footnotesOption = self.footnotesOption
         
         settings.baseFontSize = self.useBaseFontSize ? self.baseFontSize : 0

--- a/examples/toc-anchor-test.md
+++ b/examples/toc-anchor-test.md
@@ -1,0 +1,79 @@
+# TOC Anchor-Scroll Test
+
+This document exists to test whether clicking a table-of-contents link scrolls
+the Quick Look preview to the target heading. It is intentionally long.
+
+## Introduction
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+
+### Background
+
+Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.
+
+### Motivation
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error.
+
+## Architecture
+
+Sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt.
+
+### Rendering Pipeline
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed
+quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+
+### Extensions
+
+Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore.
+
+## Configuration
+
+Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum
+soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime.
+
+### Settings UI
+
+Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe
+eveniet ut et voluptates repudiandae sint et molestiae non recusandae.
+
+### Defaults
+
+Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus
+maiores alias consequatur aut perferendis doloribus asperiores repellat.
+
+## Testing
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam quis.
+
+### Unit Tests
+
+Nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis
+aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat.
+
+### Manual QA
+
+Nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui
+officia deserunt mollit anim id est laborum sed perspiciatis unde omnis.
+
+## Conclusion
+
+Iste natus error sit voluptatem accusantium doloremque laudantium totam rem aperiam
+eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae.
+
+### Future Work
+
+Dicta sunt explicabo nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+odit aut fugit sed quia consequuntur magni dolores eos qui ratione.
+
+### References
+
+Voluptatem sequi nesciunt neque porro quisquam est qui dolorem ipsum quia dolor
+sit amet consectetur adipisci velit sed quia non numquam eius modi tempora.

--- a/examples/toc-edge-cases/01-skipped-reverse-levels.md
+++ b/examples/toc-edge-cases/01-skipped-reverse-levels.md
@@ -1,0 +1,35 @@
+# Top Level One (H1)
+
+Levels jump around on purpose — the TOC indentation should not break.
+
+### Straight to H3 (skipped H2)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+###### Now H6 (skipped H4 and H5)
+
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+## Back up to H2
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+
+#### H4 nested under that H2
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse.
+
+# Second H1 Near the Middle
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
+
+##### Orphan H5 (no H4 parent above it)
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.
+
+## Final H2
+
+Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.
+
+###### Trailing H6
+
+Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse.

--- a/examples/toc-edge-cases/02-formatting-in-headings.md
+++ b/examples/toc-edge-cases/02-formatting-in-headings.md
@@ -1,0 +1,27 @@
+# Formatting Inside Headings
+
+The TOC should show clean text — tags stripped, entities/emoji preserved.
+
+## Heading with **bold**, *italic*, and `inline code`
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+### A [link in a heading](https://example.com) keeps only the text
+
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+#### Emoji shortcodes :rocket: :tada: and a raw 🎉 in a heading
+
+Ut enim ad minim veniam, quis nostrud exercitation.
+
+##### Entities: A &amp; B &lt; C &gt; D and "smart quotes" — em–dash
+
+Duis aute irure dolor in reprehenderit in voluptate.
+
+###### Chemistry H~2~O and powers X^2^ plus ~~strikethrough~~ in a heading
+
+Excepteur sint occaecat cupidatat non proident.
+
+## Heading with <em>raw HTML</em> and an ![inline image](x.png) reference
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur.

--- a/examples/toc-edge-cases/03-duplicate-slugs.md
+++ b/examples/toc-edge-cases/03-duplicate-slugs.md
@@ -1,0 +1,36 @@
+# Duplicate & Colliding Headings
+
+Several headings share text/slug — clicking each TOC entry may all jump to the
+first match (heads anchor IDs can collide). Watch where each one scrolls.
+
+## Details
+
+First "Details" section. Lorem ipsum dolor sit amet.
+
+## Details
+
+Second "Details" — identical text. Consectetur adipiscing elit.
+
+## details
+
+Lowercase "details" variant. Sed do eiusmod tempor.
+
+## Details!
+
+"Details" with punctuation. Ut enim ad minim veniam.
+
+## Duplicate & Colliding Headings
+
+Repeat of the H1 title text. Duis aute irure dolor.
+
+## Section
+
+A. Quis nostrud exercitation ullamco laboris.
+
+## Section
+
+B. Excepteur sint occaecat cupidatat non proident.
+
+## Section
+
+C. Nemo enim ipsam voluptatem quia voluptas.

--- a/examples/toc-edge-cases/04-many-headings.md
+++ b/examples/toc-edge-cases/04-many-headings.md
@@ -1,0 +1,78 @@
+# Many Headings — Sidebar Scroll Test
+
+40+ headings so the TOC sidebar overflows its own height and must scroll
+independently while its sticky position holds.
+
+## Section 01
+Filler.
+## Section 02
+Filler.
+### Sub 02.a
+Filler.
+### Sub 02.b
+Filler.
+## Section 03
+Filler.
+## Section 04
+Filler.
+### Sub 04.a
+Filler.
+## Section 05
+Filler.
+## Section 06
+Filler.
+## Section 07
+Filler.
+### Sub 07.a
+Filler.
+### Sub 07.b
+Filler.
+### Sub 07.c
+Filler.
+## Section 08
+Filler.
+## Section 09
+Filler.
+## Section 10
+Filler.
+## Section 11
+Filler.
+## Section 12
+Filler.
+## Section 13
+Filler.
+## Section 14
+Filler.
+## Section 15
+Filler.
+## Section 16
+Filler.
+## Section 17
+Filler.
+## Section 18
+Filler.
+## Section 19
+Filler.
+## Section 20
+Filler.
+## Section 21
+Filler.
+## Section 22
+Filler.
+## Section 23
+Filler.
+## Section 24
+Filler.
+## Section 25
+Filler.
+## Section 26
+Filler.
+## Section 27
+Filler.
+## Section 28
+Filler.
+## Section 29
+Filler.
+## Section 30
+Filler. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.

--- a/examples/toc-edge-cases/05-long-headings.md
+++ b/examples/toc-edge-cases/05-long-headings.md
@@ -1,0 +1,23 @@
+# Long Heading Overflow Test
+
+Tests truncation / ellipsis / hover-tooltip and the percentage width.
+
+## This Is An Extremely Long Heading That Goes On And On And On And Should Definitely Overflow The Table Of Contents Sidebar Column No Matter How Wide The Preview Window Happens To Be Today
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+## Short one
+
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+### Another Ludicrously Verbose Heading Title Designed To Stress The Sidebar Layout, Containing Many Words, Several Commas, And Absolutely No Mercy For The Available Horizontal Space Whatsoever
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco.
+
+#### Supercalifragilisticexpialidocious-Antidisestablishmentarianism-Pneumonoultramicroscopicsilicovolcanoconiosis-OneVeryLongUnbrokenWordWithNoSpacesAtAllToTestWrappingBehavior
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse.
+
+## Back to normal
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa.

--- a/examples/toc-edge-cases/06-tricky-slugs-setext.md
+++ b/examples/toc-edge-cases/06-tricky-slugs-setext.md
@@ -1,0 +1,39 @@
+Setext H1 Underlined Style
+==========================
+
+Setext headings (underlined) should still get anchors and appear in the TOC.
+
+Setext H2 Underlined Style
+--------------------------
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+## 1.2.3 Numeric-Prefixed Heading
+
+Sed do eiusmod tempor incididunt ut labore.
+
+## Heading with trailing hashes ##
+
+Ut enim ad minim veniam, quis nostrud.
+
+## ¡Unïcödé Hëädïng with àccénts, ñ, and ümläüts!
+
+Duis aute irure dolor in reprehenderit.
+
+## 中文标题 with mixed 한국어 and عربى scripts
+
+Excepteur sint occaecat cupidatat non proident.
+
+## !!! @@@ ### $$$ symbols-heavy heading %%%
+
+Nemo enim ipsam voluptatem quia voluptas.
+
+##      Heading With Lots Of Leading Spaces
+
+Quis autem vel eum iure reprehenderit.
+
+## 
+
+(An empty heading above — just hashes, no text — should be skipped in the TOC.)
+
+Neque porro quisquam est, qui dolorem ipsum.

--- a/examples/toc-edge-cases/07-single-heading-no-toc.md
+++ b/examples/toc-edge-cases/07-single-heading-no-toc.md
@@ -1,0 +1,16 @@
+# The Only Heading In This File
+
+This document has **exactly one** heading, so the TOC sidebar should **not**
+appear at all — the builder requires at least two anchored headings before it
+renders a sidebar. You should see plain full-width content, no TOC column.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium
+doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore.

--- a/examples/toc-edge-cases/08-code-and-quote-headings.md
+++ b/examples/toc-edge-cases/08-code-and-quote-headings.md
@@ -1,0 +1,36 @@
+# Fake vs Real Headings
+
+Headings inside fenced/indented code must NOT show in the TOC. A heading inside
+a blockquote IS a real heading and *will* show — note where it scrolls to.
+
+## Real Heading Before Code
+
+Lorem ipsum dolor sit amet.
+
+```markdown
+## This is INSIDE a fenced code block — not a real heading
+### Neither is this one
+#### Or this
+```
+
+Text between.
+
+    ## Indented-code-block heading — also NOT a real heading
+    ### still fake
+
+## Real Heading After Code
+
+Sed do eiusmod tempor incididunt ut labore.
+
+> ## Heading Inside A Blockquote
+>
+> This h2 lives in a blockquote — cmark still gives it an anchor, so it appears
+> in the TOC. Consectetur adipiscing elit.
+
+## Heading with `## hashes in inline code` in its text
+
+Ut enim ad minim veniam, quis nostrud exercitation.
+
+#NotAHeading (no space after hash — this is a paragraph, not a heading)
+
+Final paragraph. Duis aute irure dolor.

--- a/qlmarkdown_cli/qlmarkdown_cli.swift
+++ b/qlmarkdown_cli/qlmarkdown_cli.swift
@@ -105,7 +105,10 @@ struct OptionsOptions: ParsableArguments {
     
     @Option(help: ArgumentHelp("Parse the footnotes.", valueName: "on|off"))
     var footnotes: BoolArgumentEnum? = nil
-    
+
+    @Option(help: ArgumentHelp("Show a table-of-contents sidebar in the preview.", valueName: "on|off"))
+    var tableOfContents: BoolArgumentEnum? = nil
+
     @Option(help: ArgumentHelp("Render soft-break elements as hard line breaks.", valueName: "on|off"))
     var hardBreak: BoolArgumentEnum? = nil
     
@@ -250,6 +253,9 @@ struct QLMarkdownCLI: ParsableCommand {
         if let o = options.footnotes {
             settings.footnotesOption = o == .on
         }
+        if let o = options.tableOfContents {
+            settings.tableOfContentsOption = o == .on
+        }
         if let o = options.hardBreak {
             settings.hardBreakOption = o == .on
         }
@@ -388,6 +394,7 @@ struct QLMarkdownCLI: ParsableCommand {
         print("    --appearance: \(appearance)")
         print("    --base-font-size: \(settings.baseFontSize > 0 ? "\(settings.baseFontSize) pt" : "auto")")
         print("    --footnotes: \(settings.footnotesOption ? "on" : "off")")
+        print("    --table-of-contents: \(settings.tableOfContentsOption ? "on" : "off")")
         print("    --hard-break: \(settings.hardBreakOption ? "on" : "off")")
         print("    --no-soft-break: \(settings.noSoftBreakOption ? "on" : "off")")
         print("    --raw-html: \(settings.unsafeHTMLOption ? "on" : "off")")


### PR DESCRIPTION
Build a sticky, clickable table-of-contents sidebar in getCompleteHTML from the rendered headings. It mints its own unique, clean anchors so duplicate and emoji headings each scroll correctly, independent of the heads extension. Pure HTML/CSS (no JavaScript) so it works in the data-based Quick Look preview; it collapses to full-width content on narrow previews. Gated behind a new "Table of contents" option (Settings model, Preferences checkbox, and a --table-of-contents CLI flag), off by default.

Adds examples/toc-anchor-test.md and an examples/toc-edge-cases/ set.

Addresses #161.